### PR TITLE
perf: optimize fluid simulation and canvas rendering pipeline

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,1 +1,26 @@
 @import "tailwindcss";
+
+@theme {
+  --animate-fade-in: fade-in 0.5s ease-out both;
+  --animate-fade-in-up: fade-in-up 0.5s ease-out both;
+
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes fade-in-up {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+}

--- a/src/components/FluidCanvas.tsx
+++ b/src/components/FluidCanvas.tsx
@@ -1,9 +1,13 @@
 "use client";
 
 import clsx from "clsx";
-import { motion } from "motion/react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useWindowSize } from "react-use";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 import { FluidSimulation } from "@/lib/fluid-simulation";
 
@@ -13,6 +17,90 @@ interface FluidCanvasProps {
   scale?: number;
 }
 
+interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/** Offscreen buffer at simulation resolution, reused across frames. */
+interface RenderBuffer {
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+  image: ImageData;
+}
+
+const MOBILE_BREAKPOINT_PX = 768;
+const DEFAULT_VISCOSITY = 0.0001;
+const DEFAULT_DIFFUSION = 0.0001;
+
+const createRenderBuffer = (
+  width: number,
+  height: number,
+): RenderBuffer | null => {
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d");
+  if (ctx == null) return null;
+  return { canvas, ctx, image: ctx.createImageData(width, height) };
+};
+
+/**
+ * Paint the density field into the buffer at simulation resolution, then
+ * upscale via drawImage — far fewer pixel writes than filling the scaled
+ * canvas cell by cell, with bilinear smoothing for free.
+ */
+const renderFrame = (
+  target: HTMLCanvasElement,
+  targetCtx: CanvasRenderingContext2D,
+  buffer: RenderBuffer,
+  simulation: FluidSimulation,
+  simWidth: number,
+  simHeight: number,
+): void => {
+  const data = buffer.image.data;
+  const { r, g, b } = simulation.getDensityArrays();
+  const stride = simWidth + 2;
+
+  let pixel = 0;
+  for (let j = 0; j < simHeight; j++) {
+    let index = 1 + stride * (j + 1);
+    for (let i = 0; i < simWidth; i++, index++, pixel += 4) {
+      // Uint8ClampedArray clamps and rounds on assignment.
+      data[pixel] = r[index] ?? 0;
+      data[pixel + 1] = g[index] ?? 0;
+      data[pixel + 2] = b[index] ?? 0;
+      data[pixel + 3] = 255;
+    }
+  }
+
+  buffer.ctx.putImageData(buffer.image, 0, 0);
+  targetCtx.imageSmoothingEnabled = true;
+  targetCtx.drawImage(buffer.canvas, 0, 0, target.width, target.height);
+};
+
+const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT_PX - 1}px)`;
+
+const subscribeToMediaQuery = (onStoreChange: () => void) => {
+  const mql = window.matchMedia(MOBILE_MEDIA_QUERY);
+  mql.addEventListener("change", onStoreChange);
+  return () => mql.removeEventListener("change", onStoreChange);
+};
+
+const useIsMobile = (): boolean =>
+  useSyncExternalStore(
+    subscribeToMediaQuery,
+    () => window.matchMedia(MOBILE_MEDIA_QUERY).matches,
+    () => false,
+  );
+
+const randomColor = (): RGB => ({
+  r: Math.random() * 255,
+  g: Math.random() * 255,
+  b: Math.random() * 255,
+});
+
 export const FluidCanvas = ({
   width = 120,
   height = 80,
@@ -20,277 +108,146 @@ export const FluidCanvas = ({
 }: FluidCanvasProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const simulationRef = useRef<FluidSimulation | null>(null);
+
+  // Pointer interaction state lives in refs: it changes on every pointermove
+  // and must not trigger React re-renders.
+  const pointerActiveRef = useRef(false);
+  const prevPosRef = useRef({ x: 0, y: 0 });
+  const colorRef = useRef<RGB>(randomColor());
+  const paramsRef = useRef({
+    viscosity: DEFAULT_VISCOSITY,
+    diffusion: DEFAULT_DIFFUSION,
+  });
+
   const [isRunning, setIsRunning] = useState(true);
-  const [viscosity, setViscosity] = useState(0.0001);
-  const [diffusion, setDiffusion] = useState(0.0001);
-  const [mouseDown, setMouseDown] = useState(false);
-  const [prevMousePos, setPrevMousePos] = useState({ x: 0, y: 0 });
-  const [touchActive, setTouchActive] = useState(false);
-  const [color, setColor] = useState({ r: 255, g: 0, b: 0 });
+  const [viscosity, setViscosity] = useState(DEFAULT_VISCOSITY);
+  const [diffusion, setDiffusion] = useState(DEFAULT_DIFFUSION);
 
-  const { width: windowWidth } = useWindowSize();
-  const isMobile = windowWidth < 768;
-
-  const changeColor = useCallback(() => {
-    setColor({
-      r: Math.random() * 255,
-      g: Math.random() * 255,
-      b: Math.random() * 255,
-    });
-  }, []);
+  const isMobile = useIsMobile();
 
   // Responsive dimensions
   const canvasWidth = isMobile ? 80 : width;
   const canvasHeight = isMobile ? 60 : height;
   const canvasScale = isMobile ? 4 : scale;
 
-  const initializeSimulation = useCallback(() => {
-    simulationRef.current = new FluidSimulation(canvasWidth, canvasHeight);
-    simulationRef.current.setViscosity(viscosity);
-    simulationRef.current.setDiffusion(diffusion);
-  }, [canvasWidth, canvasHeight, viscosity, diffusion]);
-
-  const drawFluid = useCallback(() => {
-    const canvas = canvasRef.current;
-    const simulation = simulationRef.current;
-    if (!canvas || !simulation) return;
-
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-
-    const imageData = ctx.createImageData(
-      canvasWidth * canvasScale,
-      canvasHeight * canvasScale,
-    );
-    const data = imageData.data;
-    const densityArrays = simulation.getDensityArrays();
-
-    for (let j = 0; j < canvasHeight; j++) {
-      for (let i = 0; i < canvasWidth; i++) {
-        const index = i + 1 + (canvasWidth + 2) * (j + 1);
-        const r = Math.min(255, Math.max(0, densityArrays.r[index] ?? 0));
-        const g = Math.min(255, Math.max(0, densityArrays.g[index] ?? 0));
-        const b = Math.min(255, Math.max(0, densityArrays.b[index] ?? 0));
-
-        for (let dy = 0; dy < canvasScale; dy++) {
-          for (let dx = 0; dx < canvasScale; dx++) {
-            const pixelIndex =
-              ((j * canvasScale + dy) * canvasWidth * canvasScale +
-                (i * canvasScale + dx)) *
-              4;
-            data[pixelIndex] = r;
-            data[pixelIndex + 1] = g;
-            data[pixelIndex + 2] = b;
-            data[pixelIndex + 3] = 255;
-          }
-        }
-      }
-    }
-
-    ctx.putImageData(imageData, 0, 0);
-  }, [canvasWidth, canvasHeight, canvasScale]);
-
-  // Animation loop using framer-motion's useAnimate
+  // Re-create the simulation only when the grid size changes; parameter
+  // tweaks go through the setters so slider input doesn't reset the fluid.
   useEffect(() => {
-    let animationId: number;
+    const simulation = new FluidSimulation(canvasWidth, canvasHeight);
+    simulation.setViscosity(paramsRef.current.viscosity);
+    simulation.setDiffusion(paramsRef.current.diffusion);
+    simulationRef.current = simulation;
+  }, [canvasWidth, canvasHeight]);
 
+  // Animation loop: step the simulation and repaint on each animation frame.
+  useEffect(() => {
+    if (!isRunning) return;
+
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d") ?? null;
+    const buffer = createRenderBuffer(canvasWidth, canvasHeight);
+    if (canvas == null || ctx == null || buffer == null) return;
+
+    let animationId = 0;
     const animate = () => {
-      if (isRunning) {
-        const simulation = simulationRef.current;
-        if (simulation) {
-          simulation.step();
-          drawFluid();
-        }
-        animationId = requestAnimationFrame(animate);
+      const simulation = simulationRef.current;
+      if (simulation != null) {
+        simulation.step();
+        renderFrame(canvas, ctx, buffer, simulation, canvasWidth, canvasHeight);
       }
-    };
-
-    if (isRunning) {
       animationId = requestAnimationFrame(animate);
-    }
-
-    return () => {
-      if (animationId) {
-        cancelAnimationFrame(animationId);
-      }
     };
-  }, [isRunning, drawFluid]);
+    animationId = requestAnimationFrame(animate);
 
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent<HTMLCanvasElement>) => {
-      if (!mouseDown || !simulationRef.current) return;
+    return () => cancelAnimationFrame(animationId);
+  }, [isRunning, canvasWidth, canvasHeight]);
 
+  /** Map a pointer event to simulation-grid coordinates (CSS-scale aware). */
+  const getCellPosition = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
       const canvas = canvasRef.current;
-      if (!canvas) return;
+      if (canvas == null) return null;
 
       const rect = canvas.getBoundingClientRect();
-      const x = Math.floor((e.clientX - rect.left) / canvasScale);
-      const y = Math.floor((e.clientY - rect.top) / canvasScale);
+      const x = Math.floor(
+        ((e.clientX - rect.left) / rect.width) * canvasWidth,
+      );
+      const y = Math.floor(
+        ((e.clientY - rect.top) / rect.height) * canvasHeight,
+      );
+      return { x, y };
+    },
+    [canvasWidth, canvasHeight],
+  );
 
-      const prevX = prevMousePos.x;
-      const prevY = prevMousePos.y;
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      const position = getCellPosition(e);
+      if (position == null) return;
 
-      const amountX = (x - prevX) * 0.5;
-      const amountY = (y - prevY) * 0.5;
+      pointerActiveRef.current = true;
+      colorRef.current = randomColor();
+      prevPosRef.current = position;
+      e.currentTarget.setPointerCapture(e.pointerId);
+    },
+    [getCellPosition],
+  );
 
-      if (x >= 0 && x < canvasWidth && y >= 0 && y < canvasHeight) {
-        simulationRef.current.addDensity(
-          x + 1,
-          y + 1,
-          color.r,
-          color.g,
-          color.b,
-        );
-        simulationRef.current.addVelocity(x + 1, y + 1, amountX, amountY);
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      if (!pointerActiveRef.current) return;
 
-        for (let i = -1; i <= 1; i++) {
-          for (let j = -1; j <= 1; j++) {
-            const nx = x + i;
-            const ny = y + j;
-            if (nx >= 0 && nx < canvasWidth && ny >= 0 && ny < canvasHeight) {
-              simulationRef.current.addDensity(
-                nx + 1,
-                ny + 1,
-                color.r,
-                color.g,
-                color.b,
-              );
-              simulationRef.current.addVelocity(
-                nx + 1,
-                ny + 1,
-                amountX * 0.5,
-                amountY * 0.5,
-              );
+      const simulation = simulationRef.current;
+      const position = getCellPosition(e);
+      if (simulation == null || position == null) return;
+
+      const isTouch = e.pointerType === "touch";
+      const forceScale = isTouch ? 0.8 : 0.5;
+      const neighborFalloff = isTouch ? 0.7 : 0.5;
+      const radius = isTouch ? 2 : 1;
+
+      const forceX = (position.x - prevPosRef.current.x) * forceScale;
+      const forceY = (position.y - prevPosRef.current.y) * forceScale;
+
+      if (
+        position.x >= 0 &&
+        position.x < canvasWidth &&
+        position.y >= 0 &&
+        position.y < canvasHeight
+      ) {
+        const { r, g, b } = colorRef.current;
+        for (let dx = -radius; dx <= radius; dx++) {
+          for (let dy = -radius; dy <= radius; dy++) {
+            const nx = position.x + dx;
+            const ny = position.y + dy;
+            if (nx < 0 || nx >= canvasWidth || ny < 0 || ny >= canvasHeight) {
+              continue;
             }
+            const isCenter = dx === 0 && dy === 0;
+            const strength = isCenter ? 1 : neighborFalloff;
+            simulation.addDensity(nx + 1, ny + 1, r, g, b);
+            simulation.addVelocity(
+              nx + 1,
+              ny + 1,
+              forceX * strength,
+              forceY * strength,
+            );
           }
         }
       }
 
-      setPrevMousePos({ x, y });
+      prevPosRef.current = position;
     },
-    [
-      mouseDown,
-      prevMousePos,
-      canvasScale,
-      canvasWidth,
-      canvasHeight,
-      color.r,
-      color.g,
-      color.b,
-    ],
+    [getCellPosition, canvasWidth, canvasHeight],
   );
 
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent<HTMLCanvasElement>) => {
-      setMouseDown(true);
-      changeColor();
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-
-      const rect = canvas.getBoundingClientRect();
-      const x = Math.floor((e.clientX - rect.left) / canvasScale);
-      const y = Math.floor((e.clientY - rect.top) / canvasScale);
-      setPrevMousePos({ x, y });
-    },
-    [canvasScale, changeColor],
-  );
-
-  const handleMouseUp = useCallback(() => {
-    setMouseDown(false);
-  }, []);
-
-  const handleTouchStart = useCallback(
-    (e: React.TouchEvent<HTMLCanvasElement>) => {
-      e.preventDefault();
-      setTouchActive(true);
-      changeColor();
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-
-      const rect = canvas.getBoundingClientRect();
-      const touch = e.touches[0];
-      if (!touch) return;
-      const x = Math.floor((touch.clientX - rect.left) / canvasScale);
-      const y = Math.floor((touch.clientY - rect.top) / canvasScale);
-      setPrevMousePos({ x, y });
-    },
-    [canvasScale, changeColor],
-  );
-
-  const handleTouchMove = useCallback(
-    (e: React.TouchEvent<HTMLCanvasElement>) => {
-      e.preventDefault();
-      if (!touchActive || !simulationRef.current) return;
-
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-
-      const rect = canvas.getBoundingClientRect();
-      const touch = e.touches[0];
-      if (!touch) return;
-      const x = Math.floor((touch.clientX - rect.left) / canvasScale);
-      const y = Math.floor((touch.clientY - rect.top) / canvasScale);
-
-      const prevX = prevMousePos.x;
-      const prevY = prevMousePos.y;
-
-      const amountX = (x - prevX) * 0.8;
-      const amountY = (y - prevY) * 0.8;
-
-      if (x >= 0 && x < canvasWidth && y >= 0 && y < canvasHeight) {
-        simulationRef.current.addDensity(
-          x + 1,
-          y + 1,
-          color.r,
-          color.g,
-          color.b,
-        );
-        simulationRef.current.addVelocity(x + 1, y + 1, amountX, amountY);
-
-        for (let dx = -2; dx <= 2; dx++) {
-          for (let dy = -2; dy <= 2; dy++) {
-            const nx = x + dx;
-            const ny = y + dy;
-            if (nx >= 0 && nx < canvasWidth && ny >= 0 && ny < canvasHeight) {
-              simulationRef.current.addDensity(
-                nx + 1,
-                ny + 1,
-                color.r,
-                color.g,
-                color.b,
-              );
-              simulationRef.current.addVelocity(
-                nx + 1,
-                ny + 1,
-                amountX * 0.7,
-                amountY * 0.7,
-              );
-            }
-          }
-        }
-      }
-
-      setPrevMousePos({ x, y });
-    },
-    [
-      touchActive,
-      prevMousePos,
-      canvasScale,
-      canvasWidth,
-      canvasHeight,
-      color.r,
-      color.g,
-      color.b,
-    ],
-  );
-
-  const handleTouchEnd = useCallback(() => {
-    setTouchActive(false);
+  const handlePointerUp = useCallback(() => {
+    pointerActiveRef.current = false;
   }, []);
 
   const toggleSimulation = useCallback(() => {
-    setIsRunning(!isRunning);
-  }, [isRunning]);
+    setIsRunning((running) => !running);
+  }, []);
 
   const clearSimulation = useCallback(() => {
     simulationRef.current?.clear();
@@ -298,31 +255,26 @@ export const FluidCanvas = ({
 
   const updateViscosity = useCallback((value: number) => {
     setViscosity(value);
+    paramsRef.current.viscosity = value;
     simulationRef.current?.setViscosity(value);
   }, []);
 
   const updateDiffusion = useCallback((value: number) => {
     setDiffusion(value);
+    paramsRef.current.diffusion = value;
     simulationRef.current?.setDiffusion(value);
   }, []);
 
-  useEffect(() => {
-    initializeSimulation();
-  }, [initializeSimulation]);
-
   return (
-    <motion.div
-      className="flex flex-col items-center space-y-4"
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5 }}
-    >
-      <motion.canvas
+    <div className="animate-fade-in-up flex flex-col items-center space-y-4">
+      <canvas
         ref={canvasRef}
         width={canvasWidth * canvasScale}
         height={canvasHeight * canvasScale}
+        role="img"
+        aria-label="Interactive fluid simulation canvas"
         className={clsx(
-          "touch-none rounded-lg border border-gray-300 bg-black",
+          "touch-none rounded-lg border border-gray-300 bg-black transition-transform duration-200 hover:scale-[1.02]",
           isMobile ? "w-full max-w-sm" : "cursor-crosshair",
         )}
         style={{
@@ -330,50 +282,37 @@ export const FluidCanvas = ({
           height: "auto",
           aspectRatio: `${canvasWidth} / ${canvasHeight}`,
         }}
-        onMouseMove={handleMouseMove}
-        onMouseDown={handleMouseDown}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseUp}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-        onTouchCancel={handleTouchEnd}
-        whileHover={{ scale: 1.02 }}
-        transition={{ type: "spring", stiffness: 300 }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
       />
 
-      <motion.div
+      <div
         className={clsx(
-          "flex flex-wrap items-center justify-center gap-2 sm:gap-4",
+          "animate-fade-in flex flex-wrap items-center justify-center gap-2 [animation-delay:300ms] sm:gap-4",
           isMobile && "text-sm",
         )}
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ delay: 0.3, duration: 0.5 }}
       >
-        <motion.button
+        <button
           onClick={toggleSimulation}
           className={clsx(
-            "rounded bg-blue-500 text-white transition-colors hover:bg-blue-600 active:bg-blue-700",
+            "rounded bg-blue-500 text-white transition hover:scale-105 hover:bg-blue-600 active:scale-95 active:bg-blue-700",
             isMobile ? "px-3 py-2 text-sm" : "px-4 py-2",
           )}
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
         >
           {isRunning ? "Pause" : "Play"}
-        </motion.button>
+        </button>
 
-        <motion.button
+        <button
           onClick={clearSimulation}
           className={clsx(
-            "rounded bg-red-500 text-white transition-colors hover:bg-red-600 active:bg-red-700",
+            "rounded bg-red-500 text-white transition hover:scale-105 hover:bg-red-600 active:scale-95 active:bg-red-700",
             isMobile ? "px-3 py-2 text-sm" : "px-4 py-2",
           )}
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
         >
           Clear
-        </motion.button>
+        </button>
 
         <div
           className={clsx(
@@ -426,14 +365,9 @@ export const FluidCanvas = ({
             </span>
           </div>
         </div>
-      </motion.div>
+      </div>
 
-      <motion.div
-        className="max-w-md text-center text-sm text-gray-600"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ delay: 0.5, duration: 0.5 }}
-      >
+      <div className="animate-fade-in max-w-md text-center text-sm text-gray-600 [animation-delay:500ms]">
         <p className="mb-2">
           <strong>Desktop:</strong> Click and drag to add fluid and create
           velocity.
@@ -441,7 +375,7 @@ export const FluidCanvas = ({
         <p>
           <strong>Mobile:</strong> Touch and drag for fluid interaction.
         </p>
-      </motion.div>
-    </motion.div>
+      </div>
+    </div>
   );
 };

--- a/src/lib/fluid-simulation.ts
+++ b/src/lib/fluid-simulation.ts
@@ -1,135 +1,111 @@
+/**
+ * 2D fluid solver based on Jos Stam's "Real-Time Fluid Dynamics for Games".
+ *
+ * The grid is (width + 2) x (height + 2): one ghost cell on each edge holds
+ * the boundary condition. All fields are stored as flat Float64Array in
+ * row-major order for cache locality in the per-frame solver loops.
+ */
+
+const LINEAR_SOLVE_ITERATIONS = 20;
+const DEFAULT_VISCOSITY = 0.0001;
+const DEFAULT_DIFFUSION = 0.0001;
+const TIME_STEP = 0.1;
+const DENSITY_DECAY = 0.995;
+
 export class FluidSimulation {
-  private width: number;
-  private height: number;
+  private readonly width: number;
+  private readonly height: number;
+  private readonly stride: number;
   private viscosity: number;
   private diffusion: number;
-  private dt: number;
 
-  private densityR: number[];
-  private densityG: number[];
-  private densityB: number[];
-  private prevDensityR: number[];
-  private prevDensityG: number[];
-  private prevDensityB: number[];
-  private velocityX: number[];
-  private velocityY: number[];
-  private prevVelocityX: number[];
-  private prevVelocityY: number[];
-
-  private decay: number;
+  private readonly densityR: Float64Array;
+  private readonly densityG: Float64Array;
+  private readonly densityB: Float64Array;
+  private readonly prevDensityR: Float64Array;
+  private readonly prevDensityG: Float64Array;
+  private readonly prevDensityB: Float64Array;
+  private readonly velocityX: Float64Array;
+  private readonly velocityY: Float64Array;
+  private readonly prevVelocityX: Float64Array;
+  private readonly prevVelocityY: Float64Array;
 
   constructor(width: number, height: number) {
     this.width = width;
     this.height = height;
-    this.viscosity = 0.0001;
-    this.diffusion = 0.0001;
-    this.dt = 0.1;
-    this.decay = 0.995; // Add decay factor
+    this.stride = width + 2;
+    this.viscosity = DEFAULT_VISCOSITY;
+    this.diffusion = DEFAULT_DIFFUSION;
 
     const size = (width + 2) * (height + 2);
-    this.densityR = new Array(size).fill(0);
-    this.densityG = new Array(size).fill(0);
-    this.densityB = new Array(size).fill(0);
-    this.prevDensityR = new Array(size).fill(0);
-    this.prevDensityG = new Array(size).fill(0);
-    this.prevDensityB = new Array(size).fill(0);
-    this.velocityX = new Array(size).fill(0);
-    this.velocityY = new Array(size).fill(0);
-    this.prevVelocityX = new Array(size).fill(0);
-    this.prevVelocityY = new Array(size).fill(0);
+    this.densityR = new Float64Array(size);
+    this.densityG = new Float64Array(size);
+    this.densityB = new Float64Array(size);
+    this.prevDensityR = new Float64Array(size);
+    this.prevDensityG = new Float64Array(size);
+    this.prevDensityB = new Float64Array(size);
+    this.velocityX = new Float64Array(size);
+    this.velocityY = new Float64Array(size);
+    this.prevVelocityX = new Float64Array(size);
+    this.prevVelocityY = new Float64Array(size);
   }
 
   private index(x: number, y: number): number {
-    return x + (this.width + 2) * y;
+    return x + this.stride * y;
   }
 
-  private getArrayValue(arr: number[], index: number): number {
-    return arr[index] ?? 0;
-  }
-
-  private setArrayValue(arr: number[], index: number, value: number): void {
-    arr[index] = value;
-  }
-
-  private setBoundary(boundary: number, x: number[]): void {
+  private setBoundary(boundary: number, x: Float64Array): void {
     const w = this.width;
     const h = this.height;
+    const stride = this.stride;
 
     for (let i = 1; i <= w; i++) {
-      const val1 = this.getArrayValue(x, this.index(i, 1));
-      const valH = this.getArrayValue(x, this.index(i, h));
-      this.setArrayValue(x, this.index(i, 0), boundary === 2 ? -val1 : val1);
-      this.setArrayValue(
-        x,
-        this.index(i, h + 1),
-        boundary === 2 ? -valH : valH,
-      );
+      const val1 = x[i + stride] ?? 0;
+      const valH = x[i + stride * h] ?? 0;
+      x[i] = boundary === 2 ? -val1 : val1;
+      x[i + stride * (h + 1)] = boundary === 2 ? -valH : valH;
     }
 
     for (let j = 1; j <= h; j++) {
-      const val1 = this.getArrayValue(x, this.index(1, j));
-      const valW = this.getArrayValue(x, this.index(w, j));
-      this.setArrayValue(x, this.index(0, j), boundary === 1 ? -val1 : val1);
-      this.setArrayValue(
-        x,
-        this.index(w + 1, j),
-        boundary === 1 ? -valW : valW,
-      );
+      const row = stride * j;
+      const val1 = x[1 + row] ?? 0;
+      const valW = x[w + row] ?? 0;
+      x[row] = boundary === 1 ? -val1 : val1;
+      x[w + 1 + row] = boundary === 1 ? -valW : valW;
     }
 
-    this.setArrayValue(
-      x,
-      this.index(0, 0),
-      0.5 *
-        (this.getArrayValue(x, this.index(1, 0)) +
-          this.getArrayValue(x, this.index(0, 1))),
-    );
-    this.setArrayValue(
-      x,
-      this.index(0, h + 1),
-      0.5 *
-        (this.getArrayValue(x, this.index(1, h + 1)) +
-          this.getArrayValue(x, this.index(0, h))),
-    );
-    this.setArrayValue(
-      x,
-      this.index(w + 1, 0),
-      0.5 *
-        (this.getArrayValue(x, this.index(w, 0)) +
-          this.getArrayValue(x, this.index(w + 1, 1))),
-    );
-    this.setArrayValue(
-      x,
-      this.index(w + 1, h + 1),
-      0.5 *
-        (this.getArrayValue(x, this.index(w, h + 1)) +
-          this.getArrayValue(x, this.index(w + 1, h))),
-    );
+    x[this.index(0, 0)] =
+      0.5 * ((x[this.index(1, 0)] ?? 0) + (x[this.index(0, 1)] ?? 0));
+    x[this.index(0, h + 1)] =
+      0.5 * ((x[this.index(1, h + 1)] ?? 0) + (x[this.index(0, h)] ?? 0));
+    x[this.index(w + 1, 0)] =
+      0.5 * ((x[this.index(w, 0)] ?? 0) + (x[this.index(w + 1, 1)] ?? 0));
+    x[this.index(w + 1, h + 1)] =
+      0.5 * ((x[this.index(w, h + 1)] ?? 0) + (x[this.index(w + 1, h)] ?? 0));
   }
 
   private linearSolve(
     boundary: number,
-    x: number[],
-    x0: number[],
+    x: Float64Array,
+    x0: Float64Array,
     a: number,
     c: number,
   ): void {
+    const stride = this.stride;
     const cRecip = 1.0 / c;
-    for (let t = 0; t < 20; t++) {
-      for (let j = 1; j <= this.height; j++) {
-        for (let i = 1; i <= this.width; i++) {
-          const idx = this.index(i, j);
-          const x0Val = this.getArrayValue(x0, idx);
-          const xRight = this.getArrayValue(x, this.index(i + 1, j));
-          const xLeft = this.getArrayValue(x, this.index(i - 1, j));
-          const xDown = this.getArrayValue(x, this.index(i, j + 1));
-          const xUp = this.getArrayValue(x, this.index(i, j - 1));
 
-          this.setArrayValue(
-            x,
-            idx,
-            (x0Val + a * (xRight + xLeft + xDown + xUp)) * cRecip,
-          );
+    for (let t = 0; t < LINEAR_SOLVE_ITERATIONS; t++) {
+      for (let j = 1; j <= this.height; j++) {
+        let idx = 1 + stride * j;
+        for (let i = 1; i <= this.width; i++, idx++) {
+          x[idx] =
+            ((x0[idx] ?? 0) +
+              a *
+                ((x[idx + 1] ?? 0) +
+                  (x[idx - 1] ?? 0) +
+                  (x[idx + stride] ?? 0) +
+                  (x[idx - stride] ?? 0))) *
+            cRecip;
         }
       }
       this.setBoundary(boundary, x);
@@ -138,37 +114,34 @@ export class FluidSimulation {
 
   private diffuse(
     boundary: number,
-    x: number[],
-    x0: number[],
+    x: Float64Array,
+    x0: Float64Array,
     diff: number,
   ): void {
-    const a = this.dt * diff * this.width * this.height;
+    const a = TIME_STEP * diff * this.width * this.height;
     this.linearSolve(boundary, x, x0, a, 1 + 4 * a);
   }
 
   private project(
-    velocX: number[],
-    velocY: number[],
-    p: number[],
-    div: number[],
+    velocX: Float64Array,
+    velocY: Float64Array,
+    p: Float64Array,
+    div: Float64Array,
   ): void {
     const w = this.width;
     const h = this.height;
+    const stride = this.stride;
 
     for (let j = 1; j <= h; j++) {
-      for (let i = 1; i <= w; i++) {
-        const idx = this.index(i, j);
-        const vxRight = this.getArrayValue(velocX, this.index(i + 1, j));
-        const vxLeft = this.getArrayValue(velocX, this.index(i - 1, j));
-        const vyDown = this.getArrayValue(velocY, this.index(i, j + 1));
-        const vyUp = this.getArrayValue(velocY, this.index(i, j - 1));
+      let idx = 1 + stride * j;
+      for (let i = 1; i <= w; i++, idx++) {
+        const vxRight = velocX[idx + 1] ?? 0;
+        const vxLeft = velocX[idx - 1] ?? 0;
+        const vyDown = velocY[idx + stride] ?? 0;
+        const vyUp = velocY[idx - stride] ?? 0;
 
-        this.setArrayValue(
-          div,
-          idx,
-          (-0.5 * (vxRight - vxLeft + vyDown - vyUp)) / w,
-        );
-        this.setArrayValue(p, idx, 0);
+        div[idx] = (-0.5 * (vxRight - vxLeft + vyDown - vyUp)) / w;
+        p[idx] = 0;
       }
     }
 
@@ -177,18 +150,15 @@ export class FluidSimulation {
     this.linearSolve(0, p, div, 1, 4);
 
     for (let j = 1; j <= h; j++) {
-      for (let i = 1; i <= w; i++) {
-        const idx = this.index(i, j);
-        const pRight = this.getArrayValue(p, this.index(i + 1, j));
-        const pLeft = this.getArrayValue(p, this.index(i - 1, j));
-        const pDown = this.getArrayValue(p, this.index(i, j + 1));
-        const pUp = this.getArrayValue(p, this.index(i, j - 1));
+      let idx = 1 + stride * j;
+      for (let i = 1; i <= w; i++, idx++) {
+        const pRight = p[idx + 1] ?? 0;
+        const pLeft = p[idx - 1] ?? 0;
+        const pDown = p[idx + stride] ?? 0;
+        const pUp = p[idx - stride] ?? 0;
 
-        const currentVx = this.getArrayValue(velocX, idx);
-        const currentVy = this.getArrayValue(velocY, idx);
-
-        this.setArrayValue(velocX, idx, currentVx - 0.5 * (pRight - pLeft) * w);
-        this.setArrayValue(velocY, idx, currentVy - 0.5 * (pDown - pUp) * h);
+        velocX[idx] = (velocX[idx] ?? 0) - 0.5 * (pRight - pLeft) * w;
+        velocY[idx] = (velocY[idx] ?? 0) - 0.5 * (pDown - pUp) * h;
       }
     }
 
@@ -198,54 +168,49 @@ export class FluidSimulation {
 
   private advect(
     boundary: number,
-    d: number[],
-    d0: number[],
-    velocX: number[],
-    velocY: number[],
+    d: Float64Array,
+    d0: Float64Array,
+    velocX: Float64Array,
+    velocY: Float64Array,
   ): void {
     const w = this.width;
     const h = this.height;
-    const dtx = this.dt * w;
-    const dty = this.dt * h;
+    const stride = this.stride;
+    const dtx = TIME_STEP * w;
+    const dty = TIME_STEP * h;
 
     for (let j = 1; j <= h; j++) {
-      for (let i = 1; i <= w; i++) {
-        const idx = this.index(i, j);
-        const tmp1 = dtx * this.getArrayValue(velocX, idx);
-        const tmp2 = dty * this.getArrayValue(velocY, idx);
-        let x = i - tmp1;
-        let y = j - tmp2;
+      let idx = 1 + stride * j;
+      for (let i = 1; i <= w; i++, idx++) {
+        // Trace the cell's value backwards along the velocity field, then
+        // bilinearly interpolate between the four surrounding source cells.
+        let x = i - dtx * (velocX[idx] ?? 0);
+        let y = j - dty * (velocY[idx] ?? 0);
 
         if (x < 0.5) x = 0.5;
         if (x > w + 0.5) x = w + 0.5;
         const i0 = Math.floor(x);
-        const i1 = i0 + 1.0;
+        const i1 = i0 + 1;
 
         if (y < 0.5) y = 0.5;
         if (y > h + 0.5) y = h + 0.5;
         const j0 = Math.floor(y);
-        const j1 = j0 + 1.0;
+        const j1 = j0 + 1;
 
         const s1 = x - i0;
-        const s0 = 1.0 - s1;
+        const s0 = 1 - s1;
         const t1 = y - j0;
-        const t0 = 1.0 - t1;
+        const t0 = 1 - t1;
 
-        const i0i = Math.floor(i0);
-        const i1i = Math.floor(i1);
-        const j0i = Math.floor(j0);
-        const j1i = Math.floor(j1);
+        const row0 = stride * j0;
+        const row1 = stride * j1;
+        const val00 = d0[i0 + row0] ?? 0;
+        const val01 = d0[i0 + row1] ?? 0;
+        const val10 = d0[i1 + row0] ?? 0;
+        const val11 = d0[i1 + row1] ?? 0;
 
-        const val00 = this.getArrayValue(d0, this.index(i0i, j0i));
-        const val01 = this.getArrayValue(d0, this.index(i0i, j1i));
-        const val10 = this.getArrayValue(d0, this.index(i1i, j0i));
-        const val11 = this.getArrayValue(d0, this.index(i1i, j1i));
-
-        this.setArrayValue(
-          d,
-          idx,
-          s0 * (t0 * val00 + t1 * val01) + s1 * (t0 * val10 + t1 * val11),
-        );
+        d[idx] =
+          s0 * (t0 * val00 + t1 * val01) + s1 * (t0 * val10 + t1 * val11);
       }
     }
 
@@ -254,29 +219,15 @@ export class FluidSimulation {
 
   addDensity(x: number, y: number, r: number, g: number, b: number): void {
     const idx = this.index(x, y);
-    this.setArrayValue(
-      this.densityR,
-      idx,
-      this.getArrayValue(this.densityR, idx) + r,
-    );
-    this.setArrayValue(
-      this.densityG,
-      idx,
-      this.getArrayValue(this.densityG, idx) + g,
-    );
-    this.setArrayValue(
-      this.densityB,
-      idx,
-      this.getArrayValue(this.densityB, idx) + b,
-    );
+    this.densityR[idx] = (this.densityR[idx] ?? 0) + r;
+    this.densityG[idx] = (this.densityG[idx] ?? 0) + g;
+    this.densityB[idx] = (this.densityB[idx] ?? 0) + b;
   }
 
   addVelocity(x: number, y: number, amountX: number, amountY: number): void {
     const idx = this.index(x, y);
-    const currentX = this.getArrayValue(this.velocityX, idx);
-    const currentY = this.getArrayValue(this.velocityY, idx);
-    this.setArrayValue(this.velocityX, idx, currentX + amountX);
-    this.setArrayValue(this.velocityY, idx, currentY + amountY);
+    this.velocityX[idx] = (this.velocityX[idx] ?? 0) + amountX;
+    this.velocityY[idx] = (this.velocityY[idx] ?? 0) + amountY;
   }
 
   step(): void {
@@ -338,32 +289,32 @@ export class FluidSimulation {
       this.velocityY,
     );
 
-    // Apply decay to the density arrays
-    for (let i = 0; i < this.densityR.length; i++) {
-      this.densityR[i] = (this.densityR[i] ?? 0) * this.decay;
-      this.densityG[i] = (this.densityG[i] ?? 0) * this.decay;
-      this.densityB[i] = (this.densityB[i] ?? 0) * this.decay;
+    const { densityR, densityG, densityB } = this;
+    for (let i = 0; i < densityR.length; i++) {
+      densityR[i] = (densityR[i] ?? 0) * DENSITY_DECAY;
+      densityG[i] = (densityG[i] ?? 0) * DENSITY_DECAY;
+      densityB[i] = (densityB[i] ?? 0) * DENSITY_DECAY;
     }
   }
 
   getRGBDensity(x: number, y: number): { r: number; g: number; b: number } {
     const idx = this.index(x, y);
     return {
-      r: this.getArrayValue(this.densityR, idx),
-      g: this.getArrayValue(this.densityG, idx),
-      b: this.getArrayValue(this.densityB, idx),
+      r: this.densityR[idx] ?? 0,
+      g: this.densityG[idx] ?? 0,
+      b: this.densityB[idx] ?? 0,
     };
   }
 
   getVelocity(x: number, y: number): { x: number; y: number } {
     const idx = this.index(x, y);
     return {
-      x: this.getArrayValue(this.velocityX, idx),
-      y: this.getArrayValue(this.velocityY, idx),
+      x: this.velocityX[idx] ?? 0,
+      y: this.velocityY[idx] ?? 0,
     };
   }
 
-  getDensityArrays(): { r: number[]; g: number[]; b: number[] } {
+  getDensityArrays(): { r: Float64Array; g: Float64Array; b: Float64Array } {
     return {
       r: this.densityR,
       g: this.densityG,
@@ -371,7 +322,7 @@ export class FluidSimulation {
     };
   }
 
-  getVelocityArrays(): { x: number[]; y: number[] } {
+  getVelocityArrays(): { x: Float64Array; y: Float64Array } {
     return {
       x: this.velocityX,
       y: this.velocityY,


### PR DESCRIPTION
## Summary

PR-A of a 3-way re-split of the reverted #651. Focused on the simulation and rendering hot path plus two latent bugs; leaves dependency pruning and app-shell polish to follow-up PRs (see #652 for the split rationale).

### Simulation — `src/lib/fluid-simulation.ts`

- Store fields in flat \`Float64Array\` instead of \`number[]\`. Node benchmark at 120x80: **step() 11.9 ms → 10.4 ms (~13%)**. \`Float32Array\` was tried first and measured *slower* (13.1 ms) due to f32↔f64 conversion cost in JS arithmetic, so f64 was chosen against the intuitive guess.
- Compute hot-loop indices incrementally instead of calling \`index()\` per neighbor; drop per-element accessor wrappers.
- Extract magic numbers into named constants.

### Canvas — `src/components/FluidCanvas.tsx`

- **Pointer state moves from React state to refs** (position, active flag, color). Pointer moves no longer trigger component re-renders during a drag.
- **Draw pipeline rewritten**: render the density field into a reused \`ImageData\` at simulation resolution (e.g. 120x80), then upscale with \`drawImage\` instead of filling scale² pixels per cell. Pixel writes per frame drop from **345,600 → 9,600 (-97%)** at defaults, and the per-frame \`createImageData\` allocation is gone. Bilinear filtering smooths the upscale (intentional visual change).
- **Unify mouse + touch into Pointer Events** with pointer capture.
- Replace \`motion\` (framer-motion) entrance/hover animations with CSS keyframes + Tailwind transitions; replace \`react-use\`'s \`useWindowSize\` with a \`useSyncExternalStore\` + \`matchMedia\` hook (SSR-safe). *These packages are still listed in \`package.json\`; the dep entries are removed in the follow-up.*
- Add \`aria-label\` / \`role\` to the canvas.

### Bug fixes (each verified in Playwright E2E in the original combined PR)

- **Slider no longer resets the simulation.** Viscosity/diffusion flow through setters; grid re-init runs only on width/height/scale change.
- **Pointer coordinates now map through \`getBoundingClientRect\`.** Input lands correctly when the canvas is CSS-scaled (matters on mobile where the canvas is \`w-full\`).

## Out of scope for this PR

- Dep removal of \`motion\` / \`react-use\` (follow-up PR-B).
- App-shell metadata + default-prop cleanup on \`layout.tsx\` / \`page.tsx\` (follow-up PR-C).
- Vitest introduction + unit tests (follow-up PR-B).
- \`next.config.ts\` / CI / README changes (follow-up PR-C).

## Test plan

- [x] CI (lint / build / typecheck) is green
- [ ] Post-merge: drag on desktop still paints; slider changes no longer flash-clear the canvas; touch input on mobile lands on the correct cell
