### PR TITLE
fix(rules): normalize markdown italics to fix Prettier lint failures

### DIFF
--- a/.claude/rules/nextjs-opennext-version-bump.md
+++ b/.claude/rules/nextjs-opennext-version-bump.md
@@ -49,7 +49,7 @@ preview-green for this class.
 - If the failure is in OpenNext (`loadManifest`, `.open-next/*`, worker
   bootstrap): pin `next` to the last known-good version exact (no `^` —
   e.g. `"next": "15.5.20"`) and check the `@opennextjs/cloudflare`
-  release notes / issues for a fix of the *specific causing symptom*
+  release notes / issues for a fix of the _specific causing symptom_
   (the crashing manifest / loader / bootstrap path), not just a blanket
   "supports Next vX" claim — a general support statement can lag the
   actual fix.


### PR DESCRIPTION
## Summary

- 674c8ff introduced `*asterisk*` italics in `.claude/rules/nextjs-opennext-version-bump.md`, but Prettier normalises markdown italics to `_underscore_` and `pnpm run lint:prettier` is therefore red on `main` and on every PR based on it.
- All 5 currently open PRs (#657, #667, #668, #669, #670) fail the Lint check for exactly this one asterisk pair. Once this lands, rebasing each Renovate PR onto main clears the check.
- Fix is Prettier's own output — a single edit swapping `*specific causing symptom*` → `_specific causing symptom_`.

## Test plan

Nothing beyond CI.
