### PR TITLE
build: run git hooks through mise

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "test:e2e": "playwright test",
-    "prepare": "hk install"
+    "prepare": "mise exec -- hk install --mise"
   },
   "dependencies": {
     "react": "^19.2.5",


### PR DESCRIPTION
Every commit printed `Can't find lefthook in PATH` or `hk: not found`, and the
lint hook silently did nothing.

## Cause

`hk install` writes hooks that call `hk` directly:

```sh
test "${HK:-1}" = "0" || exec hk run pre-commit --from-hook "$@"
```

Git runs those in a bare `sh`, where mise has not been activated — so `hk`,
which mise installs, is not on `PATH`. The hook exited immediately and the
commit went through unlinted. Nothing failed loudly, which is why it survived
several commits.

## Fix

`hk install --mise` exists for exactly this case; it emits

```sh
test "${HK:-1}" = "0" || exec mise x -- hk run pre-commit --from-hook "$@"
```

so the pinned toolchain resolves without mise being on `PATH` at all.

## Verified

Committing from a fresh login shell now runs the hook end to end — eslint and
prettier both execute and report, where before the hook printed a
`not found` line and exited.

Two related bits of local state were also sorted out while tracking this down;
neither is part of this diff:

- A leftover `.git/hooks/prepare-commit-msg` from lefthook (replaced by hk in
  #680) was still installed and producing the `lefthook` half of the warning.
- The bare shell resolved `pnpm` 10.34.4 while `mise.toml` pins 11.20.0, so
  the hook's own `pnpm install` aborted on a modules-dir purge. Fixed by
  setting pnpm 11 as the mise global default and rebuilding `node_modules`.

## Test plan

Nothing beyond CI — the change is a build script, and the behaviour it fixes
is local to a developer's machine.
