### PR TITLE
fix: make the fluid projection isotropic and its walls actually block flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,21 @@ Textures are 32-bit float: WebGPU guarantees write-only storage access for
 those formats, while the 16-bit forms need an optional feature. They are not
 filterable in exchange, so the shaders interpolate by hand.
 
-The projection's per-axis scale factors are derived in `src/fluid/projection.ts`
-rather than written into the shader, so `projection.test.ts` can check the
-operators' identities on the CPU — the solver itself needs a GPU adapter, which
-makes those factors the one part of it a unit test can reach.
+The conversion between stored velocity and grid cells is derived in
+`src/fluid/projection.ts` rather than written into the shader, so
+`projection.test.ts` can check the operators on the CPU — the shaders need a
+GPU adapter, which makes those numbers the one part of the solver a unit test
+can reach.
 
 One deviation from a textbook solver remains: `divergence` and
 `gradientSubtract` use central differences while the Jacobi sweep solves a
 1-cell Laplacian, so the sweep does not invert the operator whose divergence it
-is given. Measured at the grid size actually used, matching the stencils only
-starts to pay off past a few hundred sweeps — well beyond the 32 the frame loop
-runs — and doing it properly means moving the velocity components onto cell
-faces, which advection and the splat would have to follow. Tracked in
+is given. Matching the stencils turns out to buy almost nothing here — measured
+at the grid size actually used, and letting the pressure field carry over
+between frames as it does on the GPU, the two schemes land within a tenth of a
+point of each other however long they run. Doing it properly also means moving
+the velocity components onto cell faces, which advection and the splat would
+have to follow. Tracked in
 [#681](https://github.com/nemolize/dreamvision/issues/681).
 
 ## Project layout

--- a/README.md
+++ b/README.md
@@ -67,13 +67,14 @@ can reach.
 One deviation from a textbook solver remains: `divergence` and
 `gradientSubtract` use central differences while the Jacobi sweep solves a
 1-cell Laplacian, so the sweep does not invert the operator whose divergence it
-is given. Matching the stencils turns out to buy almost nothing here — measured
-at the grid size actually used, and letting the pressure field carry over
-between frames as it does on the GPU, the two schemes land within a tenth of a
-point of each other however long they run. Doing it properly also means moving
-the velocity components onto cell faces, which advection and the splat would
-have to follow. Tracked in
-[#681](https://github.com/nemolize/dreamvision/issues/681).
+is given. Given enough sweeps from a cold start that costs real accuracy, but
+this solver never gets there: the pressure field carries over between frames, so
+each solve resumes the last one, and what survives is dominated by the low
+frequencies the sweep is slow on rather than by the stencil. Measured that way
+the two schemes stay within a tenth of a point of each other however long they
+run. Doing it properly also means moving the velocity components onto cell
+faces, which advection and the splat would have to follow. Numbers and the
+options are in [#681](https://github.com/nemolize/dreamvision/issues/681).
 
 ## Project layout
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,19 @@ Textures are 32-bit float: WebGPU guarantees write-only storage access for
 those formats, while the 16-bit forms need an optional feature. They are not
 filterable in exchange, so the shaders interpolate by hand.
 
-Two known deviations from a textbook solver — an anisotropic projection on
-non-square viewports, and divergence/pressure stencils that do not match — are
-tracked in [#681](https://github.com/nemolize/dreamvision/issues/681). Neither
-breaks the simulation; they affect how it feels.
+The projection's per-axis scale factors are derived in `src/fluid/projection.ts`
+rather than written into the shader, so `projection.test.ts` can check the
+operators' identities on the CPU — the solver itself needs a GPU adapter, which
+makes those factors the one part of it a unit test can reach.
+
+One deviation from a textbook solver remains: `divergence` and
+`gradientSubtract` use central differences while the Jacobi sweep solves a
+1-cell Laplacian, so the sweep does not invert the operator whose divergence it
+is given. Measured at the grid size actually used, matching the stencils only
+starts to pay off past a few hundred sweeps — well beyond the 32 the frame loop
+runs — and doing it properly means moving the velocity components onto cell
+faces, which advection and the splat would have to follow. Tracked in
+[#681](https://github.com/nemolize/dreamvision/issues/681).
 
 ## Project layout
 
@@ -87,14 +96,23 @@ breaks the simulation; they affect how it feels.
 
 ### Testing notes
 
-The solver itself has no unit tests: it needs a real GPU adapter, which Node
-has no implementation of. Its coverage comes from the Playwright suite, which
+The shaders cannot be unit-tested: they need a real GPU adapter, which Node has
+no implementation of. Their coverage comes from the Playwright suite, which
 drives a real drag and then asserts the picture keeps changing after the
 pointer is released. That second assertion is the load-bearing one: lit pixels
 alone prove nothing, since the splat pass writes colour straight under the
 drag path — only advection over a projected velocity field keeps the field
 moving with no further input. Verified by disabling advection and confirming
 the suite fails.
+
+What that suite cannot see is whether the projection is _right_: a wrong sign,
+a swapped axis, or a missing per-axis weight still leaves something that looks
+like a fluid. `projection.test.ts` covers that gap by rebuilding the discrete
+operators from the factors in `projection.ts` and checking the identities they
+have to satisfy. It is a check on the derivation, not on the shader — the
+operators are transcribed by hand, so editing a projection pass means editing
+its twin in the test. Verified by mutation: reverting each factor to a wrong
+value fails at least one assertion.
 
 E2E runs against the Vite dev server by default; in CI (and with `E2E_PREVIEW=1`
 locally) it runs against the production build served by the Workers runtime.

--- a/README.md
+++ b/README.md
@@ -67,14 +67,15 @@ can reach.
 One deviation from a textbook solver remains: `divergence` and
 `gradientSubtract` use central differences while the Jacobi sweep solves a
 1-cell Laplacian, so the sweep does not invert the operator whose divergence it
-is given. Given enough sweeps from a cold start that costs real accuracy, but
-this solver never gets there: the pressure field carries over between frames, so
-each solve resumes the last one, and what survives is dominated by the low
-frequencies the sweep is slow on rather than by the stencil. Measured that way
-the two schemes stay within a tenth of a point of each other however long they
-run. Doing it properly also means moving the velocity components onto cell
-faces, which advection and the splat would have to follow. Numbers and the
-options are in [#681](https://github.com/nemolize/dreamvision/issues/681).
+is given. From a cold start, enough sweeps would make that cost real accuracy —
+but this solver never solves cold: the pressure field carries over between
+frames, so each solve resumes the last one, and what survives is dominated by
+the low frequencies the sweep is slow on rather than by the stencil. Measured
+that way the two schemes converge on each other as the loop runs, to within a
+tenth of a point. Doing it properly also means moving the velocity components
+onto cell faces, which advection and the splat would have to follow. Numbers and
+the options are in
+[#681](https://github.com/nemolize/dreamvision/issues/681).
 
 ## Project layout
 

--- a/src/fluid/projection.test.ts
+++ b/src/fluid/projection.test.ts
@@ -1,0 +1,491 @@
+import { describe, expect, it } from "vitest";
+
+import { PRESSURE_ITERATIONS, SIM_RESOLUTION } from "./config";
+import { jacobiDiagonal, projectionScale } from "./projection";
+
+/**
+ * The discrete operators the projection passes implement, rebuilt here from
+ * the factors `projection.ts` derives, so their identities can be checked
+ * without a GPU. A wrong sign, a swapped axis, or a missing aspect term is
+ * invisible to the Playwright suite — the fluid still looks like a fluid —
+ * but breaks an assertion below.
+ *
+ * The operators are transcribed from `simulation.wgsl` by hand, so this checks
+ * the derivation, not the shader: editing a projection pass means editing its
+ * twin here.
+ */
+
+interface Field {
+  readonly width: number;
+  readonly height: number;
+  readonly data: Float64Array;
+}
+
+const field = (width: number, height: number): Field => ({
+  width,
+  height,
+  data: new Float64Array(width * height),
+});
+
+/** Reads outside the grid clamp to the edge, matching `loadAt`. */
+const at = (f: Field, x: number, y: number): number => {
+  const cx = Math.min(Math.max(x, 0), f.width - 1);
+  const cy = Math.min(Math.max(y, 0), f.height - 1);
+  return f.data[cy * f.width + cx] ?? 0;
+};
+
+const set = (f: Field, x: number, y: number, value: number): void => {
+  f.data[y * f.width + x] = value;
+};
+
+interface Velocity {
+  readonly x: Field;
+  readonly y: Field;
+}
+
+const velocity = (width: number, height: number): Velocity => ({
+  x: field(width, height),
+  y: field(width, height),
+});
+
+/**
+ * The `divergence` pass: a central difference per axis, each scaled into the
+ * physical metric, with the outside sample mirrored at a wall so no flow
+ * crosses it.
+ */
+const divergence = (u: Velocity, aspect: number): Field => {
+  const { width, height } = u.x;
+  const scale = projectionScale(width, height, aspect);
+  const out = field(width, height);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const centreX = at(u.x, x, y);
+      const centreY = at(u.y, x, y);
+
+      const left = x === 0 ? -centreX : at(u.x, x - 1, y);
+      const right = x === width - 1 ? -centreX : at(u.x, x + 1, y);
+      const down = y === 0 ? -centreY : at(u.y, x, y - 1);
+      const up = y === height - 1 ? -centreY : at(u.y, x, y + 1);
+
+      set(
+        out,
+        x,
+        y,
+        0.5 * scale.divergenceX * (right - left) +
+          0.5 * scale.divergenceY * (up - down),
+      );
+    }
+  }
+  return out;
+};
+
+/**
+ * The pressure gradient `gradientSubtract` removes, as its own operator so the
+ * adjoint identity can be checked against `divergence`.
+ */
+const gradient = (p: Field, aspect: number): Velocity => {
+  const { width, height } = p;
+  const scale = projectionScale(width, height, aspect);
+  const out = velocity(width, height);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      set(
+        out.x,
+        x,
+        y,
+        0.5 * scale.gradientX * (at(p, x + 1, y) - at(p, x - 1, y)),
+      );
+      set(
+        out.y,
+        x,
+        y,
+        0.5 * scale.gradientY * (at(p, x, y + 1) - at(p, x, y - 1)),
+      );
+    }
+  }
+  return out;
+};
+
+/** The Laplacian the Jacobi sweep inverts, written out as an operator. */
+const laplacian = (p: Field, aspect: number): Field => {
+  const { width, height } = p;
+  const scale = projectionScale(width, height, aspect);
+  const diagonal = jacobiDiagonal(scale);
+  const out = field(width, height);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      set(
+        out,
+        x,
+        y,
+        scale.laplacianX * (at(p, x + 1, y) + at(p, x - 1, y)) +
+          scale.laplacianY * (at(p, x, y + 1) + at(p, x, y - 1)) -
+          diagonal * at(p, x, y),
+      );
+    }
+  }
+  return out;
+};
+
+/** One Jacobi sweep, transcribed from the `pressure` entry point. */
+const jacobiSweep = (p: Field, rhs: Field, aspect: number): Field => {
+  const { width, height } = p;
+  const scale = projectionScale(width, height, aspect);
+  const diagonal = jacobiDiagonal(scale);
+  const out = field(width, height);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const neighbours =
+        scale.laplacianX * (at(p, x + 1, y) + at(p, x - 1, y)) +
+        scale.laplacianY * (at(p, x, y + 1) + at(p, x, y - 1));
+      set(out, x, y, (neighbours - at(rhs, x, y)) / diagonal);
+    }
+  }
+  return out;
+};
+
+const solvePressure = (rhs: Field, aspect: number, sweeps: number): Field => {
+  let p = field(rhs.width, rhs.height);
+  for (let i = 0; i < sweeps; i++) p = jacobiSweep(p, rhs, aspect);
+  return p;
+};
+
+/** Interior cells only: the walls carry the boundary condition, not the field. */
+const l2Interior = (f: Field): number => {
+  let sum = 0;
+  for (let y = 1; y < f.height - 1; y++) {
+    for (let x = 1; x < f.width - 1; x++) {
+      const v = at(f, x, y);
+      sum += v * v;
+    }
+  }
+  return Math.sqrt(sum);
+};
+
+const fillVelocity = (
+  u: Velocity,
+  fx: (x: number, y: number) => number,
+  fy: (x: number, y: number) => number,
+): void => {
+  for (let y = 0; y < u.x.height; y++) {
+    for (let x = 0; x < u.x.width; x++) {
+      set(u.x, x, y, fx(x, y));
+      set(u.y, x, y, fy(x, y));
+    }
+  }
+};
+
+const fillField = (f: Field, fn: (x: number, y: number) => number): void => {
+  for (let y = 0; y < f.height; y++) {
+    for (let x = 0; x < f.width; x++) set(f, x, y, fn(x, y));
+  }
+};
+
+describe("projectionScale", () => {
+  it("weights the two axes equally when the cells are square", () => {
+    // A 16:9 canvas on a 16:9 grid: the cells come out square, so neither axis
+    // should be favoured even though the cell *counts* differ by 16/9.
+    const scale = projectionScale(320, 180, 16 / 9);
+    expect(scale.divergenceX).toBeCloseTo(scale.divergenceY, 6);
+    expect(scale.laplacianX).toBeCloseTo(scale.laplacianY, 6);
+  });
+
+  it("weights the axes apart when the cells are not square", () => {
+    // `fitGrid`'s two-cell floor produces this at extreme aspects, and it is
+    // exactly the case a single shared cell size would get wrong.
+    const scale = projectionScale(320, 2, 300);
+    const cellX = 300 / 320;
+    const cellY = 1 / 2;
+    expect(scale.divergenceX / scale.divergenceY).toBeCloseTo(cellY / cellX, 6);
+  });
+
+  it("derives every factor from the same two cell sizes", () => {
+    const scale = projectionScale(97, 41, 2.3);
+    expect(scale.gradientX).toBeCloseTo(scale.divergenceX, 9);
+    expect(scale.gradientY).toBeCloseTo(scale.divergenceY, 9);
+    expect(scale.laplacianX).toBeCloseTo(scale.divergenceX ** 2, 9);
+    expect(scale.laplacianY).toBeCloseTo(scale.divergenceY ** 2, 9);
+  });
+
+  it("scales as an inverse length", () => {
+    const coarse = projectionScale(32, 18, 16 / 9);
+    const fine = projectionScale(64, 36, 16 / 9);
+    expect(fine.divergenceX / coarse.divergenceX).toBeCloseTo(2, 6);
+    expect(fine.laplacianX / coarse.laplacianX).toBeCloseTo(4, 6);
+  });
+});
+
+describe("jacobiDiagonal", () => {
+  it("reduces to the textbook 4 / h² on a square grid", () => {
+    // The uniform-cell solver hard-codes a 0.25 multiplier, i.e. a diagonal of
+    // 4 in units where h = 1. The weighted form has to agree there.
+    const scale = projectionScale(16, 16, 1);
+    expect(jacobiDiagonal(scale)).toBeCloseTo(4 * 16 * 16, 6);
+  });
+
+  it("is the sum of the weights the sweep spreads over the neighbours", () => {
+    const scale = projectionScale(40, 13, 3.1);
+    expect(jacobiDiagonal(scale)).toBeCloseTo(
+      2 * scale.laplacianX + 2 * scale.laplacianY,
+      9,
+    );
+  });
+});
+
+describe("the discrete operators", () => {
+  it("measures no divergence in a uniform flow", () => {
+    const u = velocity(12, 7);
+    fillVelocity(
+      u,
+      () => 0.4,
+      () => -0.2,
+    );
+    // The walls do carry divergence — that is the free-slip condition biting,
+    // not an error — so the interior is what must come out clean.
+    expect(l2Interior(divergence(u, 16 / 9))).toBeCloseTo(0, 9);
+  });
+
+  it("measures a pure expansion as positive divergence", () => {
+    const u = velocity(9, 9);
+    fillVelocity(
+      u,
+      (x) => x,
+      (_x, y) => y,
+    );
+    const d = divergence(u, 1);
+    expect(at(d, 4, 4)).toBeGreaterThan(0);
+  });
+
+  it("measures the same divergence for a flow rotated by a quarter turn", () => {
+    // The anisotropy of #681 shows up precisely here: before the per-axis
+    // factors, the same physical flow read as different divergences depending
+    // on which way it pointed.
+    const aspect = 16 / 9;
+    const width = 32;
+    const height = 18;
+
+    const horizontal = velocity(width, height);
+    fillVelocity(
+      horizontal,
+      (x) => (x / width) * aspect,
+      () => 0,
+    );
+
+    const vertical = velocity(width, height);
+    fillVelocity(
+      vertical,
+      () => 0,
+      (_x, y) => y / height,
+    );
+
+    const dH = divergence(horizontal, aspect);
+    const dV = divergence(vertical, aspect);
+    expect(at(dH, 16, 9)).toBeCloseTo(at(dV, 16, 9), 6);
+  });
+
+  it("does NOT compose into the Laplacian the Jacobi sweep inverts", () => {
+    // #681's second defect, pinned as the gap it currently is: a central
+    // difference on both sides composes to a 2-cell Laplacian, not the 1-cell
+    // operator the sweep solves. Fixing the stencils flips this assertion.
+    const aspect = 16 / 9;
+    const p = field(24, 14);
+    fillField(p, (x, y) => Math.sin(x * 0.3) * Math.cos(y * 0.45));
+
+    const composed = divergence(gradient(p, aspect), aspect);
+    const direct = laplacian(p, aspect);
+
+    const difference = field(p.width, p.height);
+    for (let i = 0; i < difference.data.length; i++) {
+      difference.data[i] = (composed.data[i] ?? 0) - (direct.data[i] ?? 0);
+    }
+    expect(l2Interior(difference) / l2Interior(direct)).toBeGreaterThan(0.1);
+  });
+});
+
+describe("the Jacobi sweep", () => {
+  it("leaves the exact solution where it is", () => {
+    const aspect = 16 / 9;
+    const p = field(20, 12);
+    fillField(p, (x, y) => Math.sin(x * 0.4) * Math.sin(y * 0.6));
+
+    const rhs = laplacian(p, aspect);
+    const swept = jacobiSweep(p, rhs, aspect);
+
+    const difference = field(p.width, p.height);
+    for (let i = 0; i < difference.data.length; i++) {
+      difference.data[i] = (swept.data[i] ?? 0) - (p.data[i] ?? 0);
+    }
+    expect(l2Interior(difference) / l2Interior(p)).toBeLessThan(1e-9);
+  });
+
+  /** Sweep a starting error towards the zero solution and report what remains. */
+  const surviving = (start: Field, aspect: number, sweeps: number): number => {
+    const zero = field(start.width, start.height);
+    let current = start;
+    for (let i = 0; i < sweeps; i++)
+      current = jacobiSweep(current, zero, aspect);
+    return l2Interior(current) / l2Interior(start);
+  };
+
+  it("barely damps a checkerboard it is handed", () => {
+    // The sweep amplifies by (cos kx + cos ky) / 2 — exactly -1 at (pi, pi) —
+    // so a checkerboard survives every sweep and only the walls erode it, over
+    // a distance the real grid does not give them.
+    const error = field(SIM_RESOLUTION, 180);
+    fillField(error, (x, y) => ((x + y) % 2 === 0 ? 1 : -1));
+
+    expect(surviving(error, 16 / 9, PRESSURE_ITERATIONS)).toBeGreaterThan(0.95);
+  });
+
+  it("hides that on a grid small enough for the walls to reach", () => {
+    // The same error decays by half on a 16x16 grid, so a test at a convenient
+    // size reports the sweep as healthy. Pinned so the test above cannot be
+    // quietly shrunk back into this regime.
+    const error = field(16, 16);
+    fillField(error, (x, y) => ((x + y) % 2 === 0 ? 1 : -1));
+
+    expect(surviving(error, 1, PRESSURE_ITERATIONS)).toBeLessThan(0.6);
+  });
+
+  it("never raises a checkerboard the divergence did not contain", () => {
+    // Why the mode above costs nothing in practice, and why a weighted sweep
+    // would be the wrong fix: an amplification of -1 neither damps NOR grows
+    // the mode, and the solve starts from zero — so with a smooth divergence
+    // driving it, no checkerboard is ever created to need damping.
+    const aspect = 16 / 9;
+    const u = velocity(64, 36);
+    fillVelocity(
+      u,
+      (x, y) => Math.sin(x * 0.2) * Math.cos(y * 0.15),
+      (x, y) => Math.cos(x * 0.1) * Math.sin(y * 0.25),
+    );
+
+    const p = solvePressure(divergence(u, aspect), aspect, PRESSURE_ITERATIONS);
+
+    // Project the pressure onto the (pi, pi) mode and compare with its overall
+    // magnitude: a field carrying real checkerboard would score near 1.
+    let alternating = 0;
+    let cells = 0;
+    for (let y = 1; y < p.height - 1; y++) {
+      for (let x = 1; x < p.width - 1; x++) {
+        alternating += at(p, x, y) * ((x + y) % 2 === 0 ? 1 : -1);
+        cells++;
+      }
+    }
+    const share = Math.abs(alternating) / Math.sqrt(cells) / l2Interior(p);
+    expect(share).toBeLessThan(0.001);
+  });
+
+  it("damps a mid-frequency mode at the same resolution", () => {
+    // Same grid and sweep count as the checkerboard test, so the contrast
+    // isolates the frequency rather than the geometry.
+    const error = field(SIM_RESOLUTION, 180);
+    fillField(
+      error,
+      (x, y) => Math.sin((x * Math.PI) / 2) * Math.sin((y * Math.PI) / 2),
+    );
+
+    expect(surviving(error, 16 / 9, PRESSURE_ITERATIONS)).toBeLessThan(0.05);
+  });
+});
+
+describe("the projection as a whole", () => {
+  const project = (u: Velocity, aspect: number, sweeps: number): Velocity => {
+    const rhs = divergence(u, aspect);
+    const p = solvePressure(rhs, aspect, sweeps);
+    const g = gradient(p, aspect);
+    const out = velocity(u.x.width, u.x.height);
+    fillVelocity(
+      out,
+      (x, y) => at(u.x, x, y) - at(g.x, x, y),
+      (x, y) => at(u.y, x, y) - at(g.y, x, y),
+    );
+    return out;
+  };
+
+  it("reduces the divergence of a compressible flow", () => {
+    const aspect = 16 / 9;
+    const u = velocity(24, 14);
+    fillVelocity(
+      u,
+      (x, y) => Math.sin(x * 0.5) * Math.cos(y * 0.3),
+      (x, y) => Math.cos(x * 0.2) * Math.sin(y * 0.7),
+    );
+
+    const before = l2Interior(divergence(u, aspect));
+    const after = l2Interior(divergence(project(u, aspect, 64), aspect));
+    expect(after).toBeLessThan(before);
+  });
+
+  it("treats a flow and its quarter-turn rotation alike on a square grid", () => {
+    // Rotational symmetry is the property the anisotropy destroyed. On a
+    // square grid with a square canvas the projection must not care which axis
+    // the flow runs along.
+    const size = 16;
+    const sweeps = 64;
+
+    const horizontal = velocity(size, size);
+    fillVelocity(
+      horizontal,
+      (x) => Math.sin(x * 0.4),
+      () => 0,
+    );
+
+    const vertical = velocity(size, size);
+    fillVelocity(
+      vertical,
+      () => 0,
+      (_x, y) => Math.sin(y * 0.4),
+    );
+
+    const ph = solvePressure(divergence(horizontal, 1), 1, sweeps);
+    const pv = solvePressure(divergence(vertical, 1), 1, sweeps);
+
+    // The two pressure fields are each other's transpose if the operator has
+    // no directional bias.
+    let worst = 0;
+    for (let y = 1; y < size - 1; y++) {
+      for (let x = 1; x < size - 1; x++) {
+        worst = Math.max(worst, Math.abs(at(ph, x, y) - at(pv, y, x)));
+      }
+    }
+    expect(worst / l2Interior(ph)).toBeLessThan(1e-9);
+  });
+
+  it("stays symmetric on a non-square canvas once the metric is carried", () => {
+    // The regression #681 describes: with equal weights, stretching the canvas
+    // made the same physical flow read as two different divergences depending
+    // on which axis it ran along.
+    const aspect = 2;
+    const width = 32;
+    const height = 16;
+
+    // One ramp per axis, rising by the same physical amount over the same
+    // physical distance — the x component is `aspect` times larger in
+    // normalised units because the canvas is that much wider, and it spans
+    // `aspect` times as many cells.
+    const horizontal = velocity(width, height);
+    fillVelocity(
+      horizontal,
+      (x) => (x / width) * aspect,
+      () => 0,
+    );
+
+    const vertical = velocity(width, height);
+    fillVelocity(
+      vertical,
+      () => 0,
+      (_x, y) => y / height,
+    );
+
+    const dH = divergence(horizontal, aspect);
+    const dV = divergence(vertical, aspect);
+
+    // Sampled off the walls, where the free-slip mirroring dominates instead.
+    expect(at(dH, 16, 8)).toBeCloseTo(at(dV, 16, 8), 9);
+  });
+});

--- a/src/fluid/projection.test.ts
+++ b/src/fluid/projection.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { PRESSURE_ITERATIONS, SIM_RESOLUTION } from "./config";
-import { jacobiDiagonal, projectionScale } from "./projection";
+import { PRESSURE_ITERATIONS } from "./config";
+import { projectionScale } from "./projection";
 
 /**
  * The discrete operators the projection passes implement, rebuilt here from
@@ -126,23 +126,15 @@ const applyWalls = (u: Velocity): Velocity => {
   return out;
 };
 
+const neighbourSum = (p: Field, x: number, y: number): number =>
+  at(p, x + 1, y) + at(p, x - 1, y) + at(p, x, y + 1) + at(p, x, y - 1);
+
 /** The Laplacian the Jacobi sweep inverts, written out as an operator. */
 const laplacian = (p: Field): Field => {
-  const { width, height } = p;
-  const scale = projectionScale(width, height);
-  const diagonal = jacobiDiagonal(scale);
-  const out = field(width, height);
-
-  for (let y = 0; y < height; y++) {
-    for (let x = 0; x < width; x++) {
-      set(
-        out,
-        x,
-        y,
-        scale.laplacianX * (at(p, x + 1, y) + at(p, x - 1, y)) +
-          scale.laplacianY * (at(p, x, y + 1) + at(p, x, y - 1)) -
-          diagonal * at(p, x, y),
-      );
+  const out = field(p.width, p.height);
+  for (let y = 0; y < p.height; y++) {
+    for (let x = 0; x < p.width; x++) {
+      set(out, x, y, neighbourSum(p, x, y) - 4 * at(p, x, y));
     }
   }
   return out;
@@ -150,17 +142,10 @@ const laplacian = (p: Field): Field => {
 
 /** One Jacobi sweep, transcribed from the `pressure` entry point. */
 const jacobiSweep = (p: Field, rhs: Field): Field => {
-  const { width, height } = p;
-  const scale = projectionScale(width, height);
-  const diagonal = jacobiDiagonal(scale);
-  const out = field(width, height);
-
-  for (let y = 0; y < height; y++) {
-    for (let x = 0; x < width; x++) {
-      const neighbours =
-        scale.laplacianX * (at(p, x + 1, y) + at(p, x - 1, y)) +
-        scale.laplacianY * (at(p, x, y + 1) + at(p, x, y - 1));
-      set(out, x, y, (neighbours - at(rhs, x, y)) / diagonal);
+  const out = field(p.width, p.height);
+  for (let y = 0; y < p.height; y++) {
+    for (let x = 0; x < p.width; x++) {
+      set(out, x, y, (neighbourSum(p, x, y) - at(rhs, x, y)) * 0.25);
     }
   }
   return out;
@@ -184,6 +169,15 @@ const l2Interior = (f: Field): number => {
   return Math.sqrt(sum);
 };
 
+/** `|a - b| / |b|` over the interior, for how closely two fields agree. */
+const relativeDifference = (a: Field, b: Field): number => {
+  const difference = field(a.width, a.height);
+  for (let i = 0; i < difference.data.length; i++) {
+    difference.data[i] = (a.data[i] ?? 0) - (b.data[i] ?? 0);
+  }
+  return l2Interior(difference) / l2Interior(b);
+};
+
 const fillVelocity = (
   u: Velocity,
   fx: (x: number, y: number) => number,
@@ -204,51 +198,32 @@ const fillField = (f: Field, fn: (x: number, y: number) => number): void => {
 };
 
 describe("projectionScale", () => {
-  it("weights each axis by its own cell count", () => {
+  it("converts each axis by its own cell count", () => {
     // What `advect` means by the stored units: one unit of vx crosses `width`
     // cells per second, one unit of vy crosses `height`. Equal weights — the
     // state before #681 — therefore under-count x by the aspect ratio.
     const scale = projectionScale(320, 180);
     expect(scale.divergenceX).toBe(320);
     expect(scale.divergenceY).toBe(180);
-    expect(scale.divergenceY / scale.divergenceX).toBeCloseTo(180 / 320, 9);
   });
 
-  it("weights the axes equally only on a square grid", () => {
-    const scale = projectionScale(64, 64);
-    expect(scale.divergenceX).toBe(scale.divergenceY);
-    expect(scale.laplacianX).toBe(scale.laplacianY);
-  });
-
-  it("derives every factor from the same two cell counts", () => {
+  it("makes the two directions reciprocal", () => {
+    // `divergence` reads stored velocity and reports a physical rate; the
+    // gradient computes a physical correction and writes it back as stored
+    // velocity. The way out has to undo the way in, or the projection stays
+    // anisotropic in the correction while the divergence it reports still
+    // falls — an error only the written velocity reveals.
     const scale = projectionScale(97, 41);
-    expect(scale.gradientX).toBe(scale.divergenceX);
-    expect(scale.gradientY).toBe(scale.divergenceY);
-    expect(scale.laplacianX).toBe(scale.divergenceX ** 2);
-    expect(scale.laplacianY).toBe(scale.divergenceY ** 2);
+    expect(scale.divergenceX * scale.gradientX).toBeCloseTo(1, 12);
+    expect(scale.divergenceY * scale.gradientY).toBeCloseTo(1, 12);
   });
 
-  it("scales as an inverse length", () => {
-    const coarse = projectionScale(32, 18);
-    const fine = projectionScale(64, 36);
-    expect(fine.divergenceX / coarse.divergenceX).toBeCloseTo(2, 9);
-    expect(fine.laplacianX / coarse.laplacianX).toBeCloseTo(4, 9);
-  });
-});
+  it("treats the axes alike only on a square grid", () => {
+    const square = projectionScale(64, 64);
+    expect(square.divergenceX).toBe(square.divergenceY);
 
-describe("jacobiDiagonal", () => {
-  it("reduces to the textbook 4 / h² on a square grid", () => {
-    // The uniform-cell solver hard-codes a 0.25 multiplier, i.e. a diagonal of
-    // 4 in units where h = 1. The weighted form has to agree there.
-    expect(jacobiDiagonal(projectionScale(16, 16))).toBeCloseTo(4 * 16 * 16, 9);
-  });
-
-  it("is the sum of the weights the sweep spreads over the neighbours", () => {
-    const scale = projectionScale(40, 13);
-    expect(jacobiDiagonal(scale)).toBeCloseTo(
-      2 * scale.laplacianX + 2 * scale.laplacianY,
-      9,
-    );
+    const oblong = projectionScale(64, 32);
+    expect(oblong.divergenceX / oblong.divergenceY).toBe(2);
   });
 });
 
@@ -303,6 +278,21 @@ describe("the discrete operators", () => {
     );
   });
 
+  it("leaves a flow sliding along a wall alone", () => {
+    const u = velocity(24, 14);
+    fillVelocity(
+      u,
+      () => 0,
+      () => 1,
+    );
+
+    const walled = applyWalls(u);
+    // Down the left edge `vy` is tangential and must be preserved...
+    expect(at(walled.y, 0, 7)).toBe(1);
+    // ...while on the top edge the same component is normal, and goes.
+    expect(at(walled.y, 12, 0)).toBe(0);
+  });
+
   it("does NOT compose into the Laplacian the Jacobi sweep inverts", () => {
     // #681's second defect, pinned as the gap it currently is: a central
     // difference on both sides composes to a 2-cell Laplacian, not the 1-cell
@@ -310,14 +300,9 @@ describe("the discrete operators", () => {
     const p = field(24, 14);
     fillField(p, (x, y) => Math.sin(x * 0.3) * Math.cos(y * 0.45));
 
-    const composed = divergence(gradient(p));
-    const direct = laplacian(p);
-
-    const difference = field(p.width, p.height);
-    for (let i = 0; i < difference.data.length; i++) {
-      difference.data[i] = (composed.data[i] ?? 0) - (direct.data[i] ?? 0);
-    }
-    expect(l2Interior(difference) / l2Interior(direct)).toBeGreaterThan(0.1);
+    expect(
+      relativeDifference(divergence(gradient(p)), laplacian(p)),
+    ).toBeGreaterThan(0.1);
   });
 });
 
@@ -326,13 +311,9 @@ describe("the Jacobi sweep", () => {
     const p = field(20, 12);
     fillField(p, (x, y) => Math.sin(x * 0.4) * Math.sin(y * 0.6));
 
-    const swept = jacobiSweep(p, laplacian(p));
-
-    const difference = field(p.width, p.height);
-    for (let i = 0; i < difference.data.length; i++) {
-      difference.data[i] = (swept.data[i] ?? 0) - (p.data[i] ?? 0);
-    }
-    expect(l2Interior(difference) / l2Interior(p)).toBeLessThan(1e-9);
+    expect(relativeDifference(jacobiSweep(p, laplacian(p)), p)).toBeLessThan(
+      1e-9,
+    );
   });
 
   /** Sweep a starting error towards the zero solution and report what remains. */
@@ -343,24 +324,28 @@ describe("the Jacobi sweep", () => {
     return l2Interior(current) / l2Interior(start);
   };
 
+  const checkerboard = (width: number, height: number): Field => {
+    const f = field(width, height);
+    fillField(f, (x, y) => ((x + y) % 2 === 0 ? 1 : -1));
+    return f;
+  };
+
   it("barely damps a checkerboard it is handed", () => {
     // The sweep amplifies by (cos kx + cos ky) / 2 — exactly -1 at (pi, pi) —
     // so a checkerboard survives every sweep and only the walls erode it, over
-    // a distance the real grid does not give them.
-    const error = field(SIM_RESOLUTION, 180);
-    fillField(error, (x, y) => ((x + y) % 2 === 0 ? 1 : -1));
-
-    expect(surviving(error, PRESSURE_ITERATIONS)).toBeGreaterThan(0.95);
+    // a distance a full-size grid does not give them.
+    expect(
+      surviving(checkerboard(320, 180), PRESSURE_ITERATIONS),
+    ).toBeGreaterThan(0.95);
   });
 
   it("hides that on a grid small enough for the walls to reach", () => {
     // The same error decays by half on a 16x16 grid, so a test at a convenient
     // size reports the sweep as healthy. Pinned so the test above cannot be
     // quietly shrunk back into this regime.
-    const error = field(16, 16);
-    fillField(error, (x, y) => ((x + y) % 2 === 0 ? 1 : -1));
-
-    expect(surviving(error, PRESSURE_ITERATIONS)).toBeLessThan(0.6);
+    expect(surviving(checkerboard(16, 16), PRESSURE_ITERATIONS)).toBeLessThan(
+      0.6,
+    );
   });
 
   it("never raises a checkerboard the divergence did not contain", () => {
@@ -404,17 +389,16 @@ describe("the projection as a whole", () => {
     return applyWalls(subtracted);
   };
 
-  /** Net flow out through the four walls; a closed box must have none. */
-  const wallFlux = (u: Velocity): number => {
-    const { width, height } = u.x;
-    let flux = 0;
-    for (let y = 0; y < height; y++) {
-      flux += at(u.x, width - 1, y) - at(u.x, 0, y);
-    }
-    for (let x = 0; x < width; x++) {
-      flux += at(u.y, x, height - 1) - at(u.y, x, 0);
-    }
-    return flux;
+  /** The same solve without the wall pass, for comparing what it buys. */
+  const projectWithoutWalls = (u: Velocity, sweeps: number): Velocity => {
+    const g = gradient(solvePressure(divergence(u), sweeps));
+    const out = velocity(u.x.width, u.x.height);
+    fillVelocity(
+      out,
+      (x, y) => at(u.x, x, y) - at(g.x, x, y),
+      (x, y) => at(u.y, x, y) - at(g.y, x, y),
+    );
+    return out;
   };
 
   it("reduces the divergence of a compressible flow", () => {
@@ -430,11 +414,12 @@ describe("the projection as a whole", () => {
     expect(after).toBeLessThan(before);
   });
 
-  it("lets no net flow through the walls", () => {
-    // The box is closed, so whatever the interior does, the four edges must
-    // carry nothing across. Negating the normal component — which is what the
-    // pass did before — preserves its magnitude and only reverses the leak,
-    // leaving this sum as large as it started.
+  it("leaves less divergence behind for dropping the wall's normal flow", () => {
+    // Asserting the walls carry no flow would be a tautology — the pass just
+    // set those cells to zero. What is worth checking is that doing so leaves
+    // the field closer to divergence-free than leaving the walls alone, which
+    // negating the normal component (the state before) did not: it kept the
+    // magnitude and only turned the leak around.
     const u = velocity(64, 36);
     fillVelocity(
       u,
@@ -442,24 +427,9 @@ describe("the projection as a whole", () => {
       (x, y) => Math.cos(x * 0.05) * Math.sin(y * 0.09),
     );
 
-    expect(Math.abs(wallFlux(project(u, 256)))).toBeCloseTo(0, 12);
-  });
-
-  it("leaves a flow sliding along a wall alone", () => {
-    // Free-slip: the tangential component is not the projection's business, so
-    // a flow parallel to an edge must survive the wall treatment untouched.
-    const u = velocity(24, 14);
-    fillVelocity(
-      u,
-      () => 0,
-      () => 1,
-    );
-
-    const walled = applyWalls(u);
-    // Down the left edge, `vy` is tangential and must be preserved...
-    expect(at(walled.y, 0, 7)).toBe(1);
-    // ...while on the top edge the same component is normal, and goes.
-    expect(at(walled.y, 12, 0)).toBe(0);
+    const withWalls = l2Interior(divergence(project(u, 256)));
+    const without = l2Interior(divergence(projectWithoutWalls(u, 256)));
+    expect(withWalls).toBeLessThan(without);
   });
 
   it("treats a flow and its quarter-turn rotation alike on a square grid", () => {
@@ -495,48 +465,48 @@ describe("the projection as a whole", () => {
     expect(worst / l2Interior(ph)).toBeLessThan(1e-9);
   });
 
-  it("keeps that symmetry on a grid whose axes differ in resolution", () => {
-    // The regression #681 describes. The same physical flow, once along each
-    // axis, on a 2:1 grid: with equal weights the two projections disagreed by
-    // the aspect ratio, and carrying the metric brings them back together.
-    const width = 32;
-    const height = 16;
-    const sweeps = 256;
+  it("annihilates a curl-free flow on a grid whose axes differ", () => {
+    // A pure gradient field is all divergence and no rotation, so a projection
+    // that inverts its own operator takes it to nothing. This is the test that
+    // catches a conversion applied in the wrong direction: how much divergence
+    // a pass removes is invariant to that error, but how much of a removable
+    // field actually survives is not.
+    const width = 64;
+    const height = 32;
 
-    const horizontal = velocity(width, height);
-    fillVelocity(
-      horizontal,
-      (x) => Math.sin((x / width) * Math.PI),
-      () => 0,
+    const potential = field(width, height);
+    fillField(
+      potential,
+      (x, y) => Math.sin((x / width) * 3) * Math.cos((y / height) * 3),
     );
+    const curlFree = gradient(potential);
 
-    const vertical = velocity(width, height);
-    fillVelocity(
-      vertical,
-      () => 0,
-      (_x, y) => Math.sin((y / height) * Math.PI),
-    );
+    const projected = project(curlFree, 4096);
 
-    // Each flow's peak divergence, in the shared physical metric: the same
-    // profile over the same fraction of the canvas either way.
-    const peak = (f: Field): number => {
-      let worst = 0;
-      for (let y = 1; y < f.height - 1; y++) {
-        for (let x = 1; x < f.width - 1; x++) {
-          worst = Math.max(worst, Math.abs(at(f, x, y)));
-        }
+    let remaining = 0;
+    let original = 0;
+    for (let y = 1; y < height - 1; y++) {
+      for (let x = 1; x < width - 1; x++) {
+        remaining += at(projected.x, x, y) ** 2 + at(projected.y, x, y) ** 2;
+        original += at(curlFree.x, x, y) ** 2 + at(curlFree.y, x, y) ** 2;
       }
-      return worst;
-    };
+    }
+    // The residual floor is the deferred stencil mismatch, not the metric:
+    // weighting both directions alike leaves ~2.2% here against ~0.9%.
+    expect(Math.sqrt(remaining / original)).toBeLessThan(0.015);
+  });
 
-    const removedH =
-      peak(divergence(horizontal)) -
-      peak(divergence(project(horizontal, sweeps)));
-    const removedV =
-      peak(divergence(vertical)) - peak(divergence(project(vertical, sweeps)));
-    expect(removedH / peak(divergence(horizontal))).toBeCloseTo(
-      removedV / peak(divergence(vertical)),
-      2,
-    );
+  it("scales the correction by the axis it belongs to", () => {
+    // The conversion's direction, isolated. A pressure ramp along x alone
+    // produces a correction in vx alone, sized by how the stored unit maps onto
+    // that axis — reciprocally, since the difference is taken in cells and
+    // written back as stored velocity. Reversing it scales by `width²`.
+    const p = field(40, 10);
+    fillField(p, (x) => x);
+
+    const g = gradient(p);
+    const { gradientX } = projectionScale(40, 10);
+    expect(at(g.x, 20, 5)).toBeCloseTo(gradientX, 12);
+    expect(at(g.y, 20, 5)).toBeCloseTo(0, 12);
   });
 });

--- a/src/fluid/projection.test.ts
+++ b/src/fluid/projection.test.ts
@@ -108,6 +108,24 @@ const gradient = (p: Field): Velocity => {
   return out;
 };
 
+/**
+ * `applyVelocityBoundary`: free-slip walls drop the component normal to the
+ * edge and leave the tangential one alone.
+ */
+const applyWalls = (u: Velocity): Velocity => {
+  const { width, height } = u.x;
+  const out = velocity(width, height);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const onVerticalWall = x === 0 || x === width - 1;
+      const onHorizontalWall = y === 0 || y === height - 1;
+      set(out.x, x, y, onVerticalWall ? 0 : at(u.x, x, y));
+      set(out.y, x, y, onHorizontalWall ? 0 : at(u.y, x, y));
+    }
+  }
+  return out;
+};
+
 /** The Laplacian the Jacobi sweep inverts, written out as an operator. */
 const laplacian = (p: Field): Field => {
   const { width, height } = p;
@@ -373,16 +391,30 @@ describe("the Jacobi sweep", () => {
 });
 
 describe("the projection as a whole", () => {
+  /** The whole `gradientSubtract` pass, walls included. */
   const project = (u: Velocity, sweeps: number): Velocity => {
     const p = solvePressure(divergence(u), sweeps);
     const g = gradient(p);
-    const out = velocity(u.x.width, u.x.height);
+    const subtracted = velocity(u.x.width, u.x.height);
     fillVelocity(
-      out,
+      subtracted,
       (x, y) => at(u.x, x, y) - at(g.x, x, y),
       (x, y) => at(u.y, x, y) - at(g.y, x, y),
     );
-    return out;
+    return applyWalls(subtracted);
+  };
+
+  /** Net flow out through the four walls; a closed box must have none. */
+  const wallFlux = (u: Velocity): number => {
+    const { width, height } = u.x;
+    let flux = 0;
+    for (let y = 0; y < height; y++) {
+      flux += at(u.x, width - 1, y) - at(u.x, 0, y);
+    }
+    for (let x = 0; x < width; x++) {
+      flux += at(u.y, x, height - 1) - at(u.y, x, 0);
+    }
+    return flux;
   };
 
   it("reduces the divergence of a compressible flow", () => {
@@ -396,6 +428,38 @@ describe("the projection as a whole", () => {
     const before = l2Interior(divergence(u));
     const after = l2Interior(divergence(project(u, 256)));
     expect(after).toBeLessThan(before);
+  });
+
+  it("lets no net flow through the walls", () => {
+    // The box is closed, so whatever the interior does, the four edges must
+    // carry nothing across. Negating the normal component — which is what the
+    // pass did before — preserves its magnitude and only reverses the leak,
+    // leaving this sum as large as it started.
+    const u = velocity(64, 36);
+    fillVelocity(
+      u,
+      (x, y) => Math.sin(x * 0.08) * Math.cos(y * 0.06),
+      (x, y) => Math.cos(x * 0.05) * Math.sin(y * 0.09),
+    );
+
+    expect(Math.abs(wallFlux(project(u, 256)))).toBeCloseTo(0, 12);
+  });
+
+  it("leaves a flow sliding along a wall alone", () => {
+    // Free-slip: the tangential component is not the projection's business, so
+    // a flow parallel to an edge must survive the wall treatment untouched.
+    const u = velocity(24, 14);
+    fillVelocity(
+      u,
+      () => 0,
+      () => 1,
+    );
+
+    const walled = applyWalls(u);
+    // Down the left edge, `vy` is tangential and must be preserved...
+    expect(at(walled.y, 0, 7)).toBe(1);
+    // ...while on the top edge the same component is normal, and goes.
+    expect(at(walled.y, 12, 0)).toBe(0);
   });
 
   it("treats a flow and its quarter-turn rotation alike on a square grid", () => {

--- a/src/fluid/projection.test.ts
+++ b/src/fluid/projection.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { PRESSURE_ITERATIONS } from "./config";
-import { projectionScale } from "./projection";
+import { PRESSURE_ITERATIONS, SIM_RESOLUTION } from "./config";
+import { projectionScale, projectionUniform } from "./projection";
 
 /**
  * The discrete operators the projection passes implement, rebuilt here from
@@ -72,8 +72,8 @@ const divergence = (u: Velocity): Field => {
         out,
         x,
         y,
-        0.5 * scale.divergenceX * (right - left) +
-          0.5 * scale.divergenceY * (up - down),
+        0.5 * scale.toCellsX * (right - left) +
+          0.5 * scale.toCellsY * (up - down),
       );
     }
   }
@@ -95,13 +95,13 @@ const gradient = (p: Field): Velocity => {
         out.x,
         x,
         y,
-        0.5 * scale.gradientX * (at(p, x + 1, y) - at(p, x - 1, y)),
+        0.5 * scale.toStoredX * (at(p, x + 1, y) - at(p, x - 1, y)),
       );
       set(
         out.y,
         x,
         y,
-        0.5 * scale.gradientY * (at(p, x, y + 1) - at(p, x, y - 1)),
+        0.5 * scale.toStoredY * (at(p, x, y + 1) - at(p, x, y - 1)),
       );
     }
   }
@@ -203,27 +203,31 @@ describe("projectionScale", () => {
     // cells per second, one unit of vy crosses `height`. Equal weights — the
     // state before #681 — therefore under-count x by the aspect ratio.
     const scale = projectionScale(320, 180);
-    expect(scale.divergenceX).toBe(320);
-    expect(scale.divergenceY).toBe(180);
+    expect(scale.toCellsX).toBe(320);
+    expect(scale.toCellsY).toBe(180);
   });
 
   it("makes the two directions reciprocal", () => {
-    // `divergence` reads stored velocity and reports a physical rate; the
-    // gradient computes a physical correction and writes it back as stored
-    // velocity. The way out has to undo the way in, or the projection stays
-    // anisotropic in the correction while the divergence it reports still
-    // falls — an error only the written velocity reveals.
+    // The way out has to undo the way in; see `projection.ts` for why.
     const scale = projectionScale(97, 41);
-    expect(scale.divergenceX * scale.gradientX).toBeCloseTo(1, 12);
-    expect(scale.divergenceY * scale.gradientY).toBeCloseTo(1, 12);
+    expect(scale.toCellsX * scale.toStoredX).toBeCloseTo(1, 12);
+    expect(scale.toCellsY * scale.toStoredY).toBeCloseTo(1, 12);
   });
 
   it("treats the axes alike only on a square grid", () => {
     const square = projectionScale(64, 64);
-    expect(square.divergenceX).toBe(square.divergenceY);
+    expect(square.toCellsX).toBe(square.toCellsY);
 
     const oblong = projectionScale(64, 32);
-    expect(oblong.divergenceX / oblong.divergenceY).toBe(2);
+    expect(oblong.toCellsX / oblong.toCellsY).toBe(2);
+  });
+
+  it("packs each conversion into the uniform slot the shader reads it from", () => {
+    // Literals, not the record's own fields: a swap here reverses the metric on
+    // the GPU and reads as a valid one everywhere else.
+    const uniform = projectionUniform(projectionScale(64, 32));
+    expect(uniform.toCells).toEqual([64, 32]);
+    expect(uniform.toStored).toEqual([1 / 64, 1 / 32]);
   });
 });
 
@@ -278,19 +282,47 @@ describe("the discrete operators", () => {
     );
   });
 
-  it("leaves a flow sliding along a wall alone", () => {
-    const u = velocity(24, 14);
+  it("drops the normal component at each wall and keeps the tangential one", () => {
+    // Both axes, since the two edges are handled by separate branches: a
+    // regression in one of them leaves the other's assertions passing.
+    const width = 24;
+    const height = 14;
+    const u = velocity(width, height);
     fillVelocity(
       u,
-      () => 0,
+      () => 1,
       () => 1,
     );
 
     const walled = applyWalls(u);
-    // Down the left edge `vy` is tangential and must be preserved...
-    expect(at(walled.y, 0, 7)).toBe(1);
-    // ...while on the top edge the same component is normal, and goes.
-    expect(at(walled.y, 12, 0)).toBe(0);
+
+    // Left and right edges: `vx` crosses them, `vy` runs along them.
+    for (const x of [0, width - 1]) {
+      expect(at(walled.x, x, 7)).toBe(0);
+      expect(at(walled.y, x, 7)).toBe(1);
+    }
+
+    // Top and bottom edges: the roles swap.
+    for (const y of [0, height - 1]) {
+      expect(at(walled.y, 12, y)).toBe(0);
+      expect(at(walled.x, 12, y)).toBe(1);
+    }
+
+    // An interior cell keeps both.
+    expect(at(walled.x, 12, 7)).toBe(1);
+    expect(at(walled.y, 12, 7)).toBe(1);
+  });
+
+  it("converts the correction back to stored units, not into cells", () => {
+    // A unit ramp differentiates to 1 per cell; one stored unit of vx spans 40
+    // cells here, so the correction is 1/40. Reversing it gives 40. The literal
+    // is deliberate — asserting against `projectionScale` would pass either way.
+    const p = field(40, 10);
+    fillField(p, (x) => x);
+
+    const g = gradient(p);
+    expect(at(g.x, 20, 5)).toBeCloseTo(1 / 40, 12);
+    expect(at(g.y, 20, 5)).toBeCloseTo(0, 12);
   });
 
   it("does NOT compose into the Laplacian the Jacobi sweep inverts", () => {
@@ -335,7 +367,10 @@ describe("the Jacobi sweep", () => {
     // so a checkerboard survives every sweep and only the walls erode it, over
     // a distance a full-size grid does not give them.
     expect(
-      surviving(checkerboard(320, 180), PRESSURE_ITERATIONS),
+      surviving(
+        checkerboard(SIM_RESOLUTION, Math.round(SIM_RESOLUTION / 2)),
+        PRESSURE_ITERATIONS,
+      ),
     ).toBeGreaterThan(0.95);
   });
 
@@ -376,20 +411,7 @@ describe("the Jacobi sweep", () => {
 });
 
 describe("the projection as a whole", () => {
-  /** The whole `gradientSubtract` pass, walls included. */
-  const project = (u: Velocity, sweeps: number): Velocity => {
-    const p = solvePressure(divergence(u), sweeps);
-    const g = gradient(p);
-    const subtracted = velocity(u.x.width, u.x.height);
-    fillVelocity(
-      subtracted,
-      (x, y) => at(u.x, x, y) - at(g.x, x, y),
-      (x, y) => at(u.y, x, y) - at(g.y, x, y),
-    );
-    return applyWalls(subtracted);
-  };
-
-  /** The same solve without the wall pass, for comparing what it buys. */
+  /** Solve and subtract, stopping short of the wall pass. */
   const projectWithoutWalls = (u: Velocity, sweeps: number): Velocity => {
     const g = gradient(solvePressure(divergence(u), sweeps));
     const out = velocity(u.x.width, u.x.height);
@@ -400,6 +422,10 @@ describe("the projection as a whole", () => {
     );
     return out;
   };
+
+  /** The whole `gradientSubtract` pass. */
+  const project = (u: Velocity, sweeps: number): Velocity =>
+    applyWalls(projectWithoutWalls(u, sweeps));
 
   it("reduces the divergence of a compressible flow", () => {
     const u = velocity(24, 14);
@@ -416,10 +442,8 @@ describe("the projection as a whole", () => {
 
   it("leaves less divergence behind for dropping the wall's normal flow", () => {
     // Asserting the walls carry no flow would be a tautology — the pass just
-    // set those cells to zero. What is worth checking is that doing so leaves
-    // the field closer to divergence-free than leaving the walls alone, which
-    // negating the normal component (the state before) did not: it kept the
-    // magnitude and only turned the leak around.
+    // zeroed those cells. What is worth checking is that doing so leaves the
+    // field closer to divergence-free than not touching them at all.
     const u = velocity(64, 36);
     fillVelocity(
       u,
@@ -494,19 +518,5 @@ describe("the projection as a whole", () => {
     // The residual floor is the deferred stencil mismatch, not the metric:
     // weighting both directions alike leaves ~2.2% here against ~0.9%.
     expect(Math.sqrt(remaining / original)).toBeLessThan(0.015);
-  });
-
-  it("scales the correction by the axis it belongs to", () => {
-    // The conversion's direction, isolated. A pressure ramp along x alone
-    // produces a correction in vx alone, sized by how the stored unit maps onto
-    // that axis — reciprocally, since the difference is taken in cells and
-    // written back as stored velocity. Reversing it scales by `width²`.
-    const p = field(40, 10);
-    fillField(p, (x) => x);
-
-    const g = gradient(p);
-    const { gradientX } = projectionScale(40, 10);
-    expect(at(g.x, 20, 5)).toBeCloseTo(gradientX, 12);
-    expect(at(g.y, 20, 5)).toBeCloseTo(0, 12);
   });
 });

--- a/src/fluid/projection.test.ts
+++ b/src/fluid/projection.test.ts
@@ -6,7 +6,7 @@ import { jacobiDiagonal, projectionScale } from "./projection";
 /**
  * The discrete operators the projection passes implement, rebuilt here from
  * the factors `projection.ts` derives, so their identities can be checked
- * without a GPU. A wrong sign, a swapped axis, or a missing aspect term is
+ * without a GPU. A wrong sign, a swapped axis, or a missing per-axis weight is
  * invisible to the Playwright suite — the fluid still looks like a fluid —
  * but breaks an assertion below.
  *
@@ -49,13 +49,13 @@ const velocity = (width: number, height: number): Velocity => ({
 });
 
 /**
- * The `divergence` pass: a central difference per axis, each scaled into the
- * physical metric, with the outside sample mirrored at a wall so no flow
- * crosses it.
+ * The `divergence` pass: a central difference per axis, each weighted into the
+ * cell metric, with the outside sample mirrored at a wall so no flow crosses
+ * it.
  */
-const divergence = (u: Velocity, aspect: number): Field => {
+const divergence = (u: Velocity): Field => {
   const { width, height } = u.x;
-  const scale = projectionScale(width, height, aspect);
+  const scale = projectionScale(width, height);
   const out = field(width, height);
 
   for (let y = 0; y < height; y++) {
@@ -81,12 +81,12 @@ const divergence = (u: Velocity, aspect: number): Field => {
 };
 
 /**
- * The pressure gradient `gradientSubtract` removes, as its own operator so the
- * adjoint identity can be checked against `divergence`.
+ * The pressure gradient `gradientSubtract` removes, as its own operator so it
+ * can be composed against `divergence`.
  */
-const gradient = (p: Field, aspect: number): Velocity => {
+const gradient = (p: Field): Velocity => {
   const { width, height } = p;
-  const scale = projectionScale(width, height, aspect);
+  const scale = projectionScale(width, height);
   const out = velocity(width, height);
 
   for (let y = 0; y < height; y++) {
@@ -109,9 +109,9 @@ const gradient = (p: Field, aspect: number): Velocity => {
 };
 
 /** The Laplacian the Jacobi sweep inverts, written out as an operator. */
-const laplacian = (p: Field, aspect: number): Field => {
+const laplacian = (p: Field): Field => {
   const { width, height } = p;
-  const scale = projectionScale(width, height, aspect);
+  const scale = projectionScale(width, height);
   const diagonal = jacobiDiagonal(scale);
   const out = field(width, height);
 
@@ -131,9 +131,9 @@ const laplacian = (p: Field, aspect: number): Field => {
 };
 
 /** One Jacobi sweep, transcribed from the `pressure` entry point. */
-const jacobiSweep = (p: Field, rhs: Field, aspect: number): Field => {
+const jacobiSweep = (p: Field, rhs: Field): Field => {
   const { width, height } = p;
-  const scale = projectionScale(width, height, aspect);
+  const scale = projectionScale(width, height);
   const diagonal = jacobiDiagonal(scale);
   const out = field(width, height);
 
@@ -148,9 +148,9 @@ const jacobiSweep = (p: Field, rhs: Field, aspect: number): Field => {
   return out;
 };
 
-const solvePressure = (rhs: Field, aspect: number, sweeps: number): Field => {
+const solvePressure = (rhs: Field, sweeps: number): Field => {
   let p = field(rhs.width, rhs.height);
-  for (let i = 0; i < sweeps; i++) p = jacobiSweep(p, rhs, aspect);
+  for (let i = 0; i < sweeps; i++) p = jacobiSweep(p, rhs);
   return p;
 };
 
@@ -186,36 +186,35 @@ const fillField = (f: Field, fn: (x: number, y: number) => number): void => {
 };
 
 describe("projectionScale", () => {
-  it("weights the two axes equally when the cells are square", () => {
-    // A 16:9 canvas on a 16:9 grid: the cells come out square, so neither axis
-    // should be favoured even though the cell *counts* differ by 16/9.
-    const scale = projectionScale(320, 180, 16 / 9);
-    expect(scale.divergenceX).toBeCloseTo(scale.divergenceY, 6);
-    expect(scale.laplacianX).toBeCloseTo(scale.laplacianY, 6);
+  it("weights each axis by its own cell count", () => {
+    // What `advect` means by the stored units: one unit of vx crosses `width`
+    // cells per second, one unit of vy crosses `height`. Equal weights — the
+    // state before #681 — therefore under-count x by the aspect ratio.
+    const scale = projectionScale(320, 180);
+    expect(scale.divergenceX).toBe(320);
+    expect(scale.divergenceY).toBe(180);
+    expect(scale.divergenceY / scale.divergenceX).toBeCloseTo(180 / 320, 9);
   });
 
-  it("weights the axes apart when the cells are not square", () => {
-    // `fitGrid`'s two-cell floor produces this at extreme aspects, and it is
-    // exactly the case a single shared cell size would get wrong.
-    const scale = projectionScale(320, 2, 300);
-    const cellX = 300 / 320;
-    const cellY = 1 / 2;
-    expect(scale.divergenceX / scale.divergenceY).toBeCloseTo(cellY / cellX, 6);
+  it("weights the axes equally only on a square grid", () => {
+    const scale = projectionScale(64, 64);
+    expect(scale.divergenceX).toBe(scale.divergenceY);
+    expect(scale.laplacianX).toBe(scale.laplacianY);
   });
 
-  it("derives every factor from the same two cell sizes", () => {
-    const scale = projectionScale(97, 41, 2.3);
-    expect(scale.gradientX).toBeCloseTo(scale.divergenceX, 9);
-    expect(scale.gradientY).toBeCloseTo(scale.divergenceY, 9);
-    expect(scale.laplacianX).toBeCloseTo(scale.divergenceX ** 2, 9);
-    expect(scale.laplacianY).toBeCloseTo(scale.divergenceY ** 2, 9);
+  it("derives every factor from the same two cell counts", () => {
+    const scale = projectionScale(97, 41);
+    expect(scale.gradientX).toBe(scale.divergenceX);
+    expect(scale.gradientY).toBe(scale.divergenceY);
+    expect(scale.laplacianX).toBe(scale.divergenceX ** 2);
+    expect(scale.laplacianY).toBe(scale.divergenceY ** 2);
   });
 
   it("scales as an inverse length", () => {
-    const coarse = projectionScale(32, 18, 16 / 9);
-    const fine = projectionScale(64, 36, 16 / 9);
-    expect(fine.divergenceX / coarse.divergenceX).toBeCloseTo(2, 6);
-    expect(fine.laplacianX / coarse.laplacianX).toBeCloseTo(4, 6);
+    const coarse = projectionScale(32, 18);
+    const fine = projectionScale(64, 36);
+    expect(fine.divergenceX / coarse.divergenceX).toBeCloseTo(2, 9);
+    expect(fine.laplacianX / coarse.laplacianX).toBeCloseTo(4, 9);
   });
 });
 
@@ -223,12 +222,11 @@ describe("jacobiDiagonal", () => {
   it("reduces to the textbook 4 / h² on a square grid", () => {
     // The uniform-cell solver hard-codes a 0.25 multiplier, i.e. a diagonal of
     // 4 in units where h = 1. The weighted form has to agree there.
-    const scale = projectionScale(16, 16, 1);
-    expect(jacobiDiagonal(scale)).toBeCloseTo(4 * 16 * 16, 6);
+    expect(jacobiDiagonal(projectionScale(16, 16))).toBeCloseTo(4 * 16 * 16, 9);
   });
 
   it("is the sum of the weights the sweep spreads over the neighbours", () => {
-    const scale = projectionScale(40, 13, 3.1);
+    const scale = projectionScale(40, 13);
     expect(jacobiDiagonal(scale)).toBeCloseTo(
       2 * scale.laplacianX + 2 * scale.laplacianY,
       9,
@@ -246,7 +244,7 @@ describe("the discrete operators", () => {
     );
     // The walls do carry divergence — that is the free-slip condition biting,
     // not an error — so the interior is what must come out clean.
-    expect(l2Interior(divergence(u, 16 / 9))).toBeCloseTo(0, 9);
+    expect(l2Interior(divergence(u))).toBeCloseTo(0, 9);
   });
 
   it("measures a pure expansion as positive divergence", () => {
@@ -256,22 +254,21 @@ describe("the discrete operators", () => {
       (x) => x,
       (_x, y) => y,
     );
-    const d = divergence(u, 1);
-    expect(at(d, 4, 4)).toBeGreaterThan(0);
+    expect(at(divergence(u), 4, 4)).toBeGreaterThan(0);
   });
 
-  it("measures the same divergence for a flow rotated by a quarter turn", () => {
-    // The anisotropy of #681 shows up precisely here: before the per-axis
-    // factors, the same physical flow read as different divergences depending
-    // on which way it pointed.
-    const aspect = 16 / 9;
+  it("reads the same divergence from a flow and its quarter turn", () => {
+    // #681's anisotropy, as a symmetry: two flows that spread at the same
+    // physical rate, one along each axis. In the stored units a full traverse
+    // is 1.0 either way, so the same normalised ramp *is* the same physical
+    // flow — and only the per-axis weights make the two readings agree.
     const width = 32;
     const height = 18;
 
     const horizontal = velocity(width, height);
     fillVelocity(
       horizontal,
-      (x) => (x / width) * aspect,
+      (x) => x / width,
       () => 0,
     );
 
@@ -282,21 +279,21 @@ describe("the discrete operators", () => {
       (_x, y) => y / height,
     );
 
-    const dH = divergence(horizontal, aspect);
-    const dV = divergence(vertical, aspect);
-    expect(at(dH, 16, 9)).toBeCloseTo(at(dV, 16, 9), 6);
+    expect(at(divergence(horizontal), 16, 9)).toBeCloseTo(
+      at(divergence(vertical), 16, 9),
+      9,
+    );
   });
 
   it("does NOT compose into the Laplacian the Jacobi sweep inverts", () => {
     // #681's second defect, pinned as the gap it currently is: a central
     // difference on both sides composes to a 2-cell Laplacian, not the 1-cell
     // operator the sweep solves. Fixing the stencils flips this assertion.
-    const aspect = 16 / 9;
     const p = field(24, 14);
     fillField(p, (x, y) => Math.sin(x * 0.3) * Math.cos(y * 0.45));
 
-    const composed = divergence(gradient(p, aspect), aspect);
-    const direct = laplacian(p, aspect);
+    const composed = divergence(gradient(p));
+    const direct = laplacian(p);
 
     const difference = field(p.width, p.height);
     for (let i = 0; i < difference.data.length; i++) {
@@ -308,12 +305,10 @@ describe("the discrete operators", () => {
 
 describe("the Jacobi sweep", () => {
   it("leaves the exact solution where it is", () => {
-    const aspect = 16 / 9;
     const p = field(20, 12);
     fillField(p, (x, y) => Math.sin(x * 0.4) * Math.sin(y * 0.6));
 
-    const rhs = laplacian(p, aspect);
-    const swept = jacobiSweep(p, rhs, aspect);
+    const swept = jacobiSweep(p, laplacian(p));
 
     const difference = field(p.width, p.height);
     for (let i = 0; i < difference.data.length; i++) {
@@ -323,11 +318,10 @@ describe("the Jacobi sweep", () => {
   });
 
   /** Sweep a starting error towards the zero solution and report what remains. */
-  const surviving = (start: Field, aspect: number, sweeps: number): number => {
+  const surviving = (start: Field, sweeps: number): number => {
     const zero = field(start.width, start.height);
     let current = start;
-    for (let i = 0; i < sweeps; i++)
-      current = jacobiSweep(current, zero, aspect);
+    for (let i = 0; i < sweeps; i++) current = jacobiSweep(current, zero);
     return l2Interior(current) / l2Interior(start);
   };
 
@@ -338,7 +332,7 @@ describe("the Jacobi sweep", () => {
     const error = field(SIM_RESOLUTION, 180);
     fillField(error, (x, y) => ((x + y) % 2 === 0 ? 1 : -1));
 
-    expect(surviving(error, 16 / 9, PRESSURE_ITERATIONS)).toBeGreaterThan(0.95);
+    expect(surviving(error, PRESSURE_ITERATIONS)).toBeGreaterThan(0.95);
   });
 
   it("hides that on a grid small enough for the walls to reach", () => {
@@ -348,15 +342,14 @@ describe("the Jacobi sweep", () => {
     const error = field(16, 16);
     fillField(error, (x, y) => ((x + y) % 2 === 0 ? 1 : -1));
 
-    expect(surviving(error, 1, PRESSURE_ITERATIONS)).toBeLessThan(0.6);
+    expect(surviving(error, PRESSURE_ITERATIONS)).toBeLessThan(0.6);
   });
 
   it("never raises a checkerboard the divergence did not contain", () => {
     // Why the mode above costs nothing in practice, and why a weighted sweep
     // would be the wrong fix: an amplification of -1 neither damps NOR grows
-    // the mode, and the solve starts from zero — so with a smooth divergence
-    // driving it, no checkerboard is ever created to need damping.
-    const aspect = 16 / 9;
+    // the mode, and the solve starts from zero — so a smooth divergence never
+    // creates a checkerboard that would need damping.
     const u = velocity(64, 36);
     fillVelocity(
       u,
@@ -364,10 +357,8 @@ describe("the Jacobi sweep", () => {
       (x, y) => Math.cos(x * 0.1) * Math.sin(y * 0.25),
     );
 
-    const p = solvePressure(divergence(u, aspect), aspect, PRESSURE_ITERATIONS);
+    const p = solvePressure(divergence(u), PRESSURE_ITERATIONS);
 
-    // Project the pressure onto the (pi, pi) mode and compare with its overall
-    // magnitude: a field carrying real checkerboard would score near 1.
     let alternating = 0;
     let cells = 0;
     for (let y = 1; y < p.height - 1; y++) {
@@ -379,25 +370,12 @@ describe("the Jacobi sweep", () => {
     const share = Math.abs(alternating) / Math.sqrt(cells) / l2Interior(p);
     expect(share).toBeLessThan(0.001);
   });
-
-  it("damps a mid-frequency mode at the same resolution", () => {
-    // Same grid and sweep count as the checkerboard test, so the contrast
-    // isolates the frequency rather than the geometry.
-    const error = field(SIM_RESOLUTION, 180);
-    fillField(
-      error,
-      (x, y) => Math.sin((x * Math.PI) / 2) * Math.sin((y * Math.PI) / 2),
-    );
-
-    expect(surviving(error, 16 / 9, PRESSURE_ITERATIONS)).toBeLessThan(0.05);
-  });
 });
 
 describe("the projection as a whole", () => {
-  const project = (u: Velocity, aspect: number, sweeps: number): Velocity => {
-    const rhs = divergence(u, aspect);
-    const p = solvePressure(rhs, aspect, sweeps);
-    const g = gradient(p, aspect);
+  const project = (u: Velocity, sweeps: number): Velocity => {
+    const p = solvePressure(divergence(u), sweeps);
+    const g = gradient(p);
     const out = velocity(u.x.width, u.x.height);
     fillVelocity(
       out,
@@ -408,7 +386,6 @@ describe("the projection as a whole", () => {
   };
 
   it("reduces the divergence of a compressible flow", () => {
-    const aspect = 16 / 9;
     const u = velocity(24, 14);
     fillVelocity(
       u,
@@ -416,15 +393,15 @@ describe("the projection as a whole", () => {
       (x, y) => Math.cos(x * 0.2) * Math.sin(y * 0.7),
     );
 
-    const before = l2Interior(divergence(u, aspect));
-    const after = l2Interior(divergence(project(u, aspect, 64), aspect));
+    const before = l2Interior(divergence(u));
+    const after = l2Interior(divergence(project(u, 256)));
     expect(after).toBeLessThan(before);
   });
 
   it("treats a flow and its quarter-turn rotation alike on a square grid", () => {
-    // Rotational symmetry is the property the anisotropy destroyed. On a
-    // square grid with a square canvas the projection must not care which axis
-    // the flow runs along.
+    // Rotational symmetry is the property the anisotropy destroyed. On a square
+    // grid the projection must not care which axis the flow runs along, and the
+    // two pressure fields must come out as each other's transpose.
     const size = 16;
     const sweeps = 64;
 
@@ -442,11 +419,9 @@ describe("the projection as a whole", () => {
       (_x, y) => Math.sin(y * 0.4),
     );
 
-    const ph = solvePressure(divergence(horizontal, 1), 1, sweeps);
-    const pv = solvePressure(divergence(vertical, 1), 1, sweeps);
+    const ph = solvePressure(divergence(horizontal), sweeps);
+    const pv = solvePressure(divergence(vertical), sweeps);
 
-    // The two pressure fields are each other's transpose if the operator has
-    // no directional bias.
     let worst = 0;
     for (let y = 1; y < size - 1; y++) {
       for (let x = 1; x < size - 1; x++) {
@@ -456,22 +431,18 @@ describe("the projection as a whole", () => {
     expect(worst / l2Interior(ph)).toBeLessThan(1e-9);
   });
 
-  it("stays symmetric on a non-square canvas once the metric is carried", () => {
-    // The regression #681 describes: with equal weights, stretching the canvas
-    // made the same physical flow read as two different divergences depending
-    // on which axis it ran along.
-    const aspect = 2;
+  it("keeps that symmetry on a grid whose axes differ in resolution", () => {
+    // The regression #681 describes. The same physical flow, once along each
+    // axis, on a 2:1 grid: with equal weights the two projections disagreed by
+    // the aspect ratio, and carrying the metric brings them back together.
     const width = 32;
     const height = 16;
+    const sweeps = 256;
 
-    // One ramp per axis, rising by the same physical amount over the same
-    // physical distance — the x component is `aspect` times larger in
-    // normalised units because the canvas is that much wider, and it spans
-    // `aspect` times as many cells.
     const horizontal = velocity(width, height);
     fillVelocity(
       horizontal,
-      (x) => (x / width) * aspect,
+      (x) => Math.sin((x / width) * Math.PI),
       () => 0,
     );
 
@@ -479,13 +450,29 @@ describe("the projection as a whole", () => {
     fillVelocity(
       vertical,
       () => 0,
-      (_x, y) => y / height,
+      (_x, y) => Math.sin((y / height) * Math.PI),
     );
 
-    const dH = divergence(horizontal, aspect);
-    const dV = divergence(vertical, aspect);
+    // Each flow's peak divergence, in the shared physical metric: the same
+    // profile over the same fraction of the canvas either way.
+    const peak = (f: Field): number => {
+      let worst = 0;
+      for (let y = 1; y < f.height - 1; y++) {
+        for (let x = 1; x < f.width - 1; x++) {
+          worst = Math.max(worst, Math.abs(at(f, x, y)));
+        }
+      }
+      return worst;
+    };
 
-    // Sampled off the walls, where the free-slip mirroring dominates instead.
-    expect(at(dH, 16, 8)).toBeCloseTo(at(dV, 16, 8), 9);
+    const removedH =
+      peak(divergence(horizontal)) -
+      peak(divergence(project(horizontal, sweeps)));
+    const removedV =
+      peak(divergence(vertical)) - peak(divergence(project(vertical, sweeps)));
+    expect(removedH / peak(divergence(horizontal))).toBeCloseTo(
+      removedV / peak(divergence(vertical)),
+      2,
+    );
   });
 });

--- a/src/fluid/projection.ts
+++ b/src/fluid/projection.ts
@@ -1,45 +1,35 @@
 /**
- * The projection's discretisation, as plain numbers.
+ * How the projection's three passes convert between stored velocity and the
+ * grid. They only compose into a Helmholtz projection if they agree on it, and
+ * that agreement is a property of the numbers rather than of any GPU state —
+ * which is what lets `projection.test.ts` check the operators on the CPU, with
+ * no adapter.
  *
- * The three projection passes (`divergence`, `pressure`, `gradientSubtract`)
- * compose into a real Helmholtz projection only if their per-axis scale
- * factors agree. That agreement is a property of the numbers, not of any GPU
- * state, so the numbers live here rather than inside the shader — which is
- * what lets `projection.test.ts` check the operator identities on the CPU,
- * with no adapter.
+ * Velocity is stored normalised per axis, so `vx = 1` crosses the full canvas
+ * width in a second and `vy = 1` the full height; `advect` reads it that way,
+ * multiplying each component by its own grid dimension. Cells are square, so a
+ * component's speed in cells is its value times the cell count along its axis.
  *
- * Velocity is stored in normalised units per second — the canvas spans 0..1 on
- * *each* axis independently, so `vx = 1` crosses the full width in a second
- * while `vy = 1` crosses the full height. `advect` is what fixes that reading:
- * it converts to cell offsets by multiplying each component by that grid's own
- * dimension, so one unit of `vx` covers `width` cells and one unit of `vy`
- * covers `height` cells.
- *
- * Cells are square — `fitGrid` sees to that — so a cell is the natural unit of
- * length here, and the physical speed of a velocity component is its value
- * times the cell count along its axis. Hence the per-axis weights below: the x
- * difference carries `width`, the y difference `height`. Summing them with
- * equal weight, as the passes did before #681, under-counts x by the aspect
- * ratio — 44% on a 16:9 canvas.
- *
- * Confining the conversion to these three passes leaves advection, the splat,
- * and the pointer in the units they already had.
+ * The conversion runs both ways and the two are reciprocal: `divergence` reads
+ * stored velocity and reports a rate in cells, so it multiplies;
+ * `gradientSubtract` computes a correction in cells and writes it back as
+ * stored velocity, so it divides. Weighting both alike — the state this file
+ * was added to fix — leaves the projection anisotropic in the correction while
+ * the divergence it reports still falls, so only the written velocity reveals
+ * it. The two cancel in between, which is why the Jacobi sweep inverts the
+ * plain 5-point Laplacian with no weights of its own.
  */
 
 /** Per-axis factors the three projection passes must agree on. */
 export interface ProjectionScale {
-  /** Multiplies the x difference in `divergence`. */
+  /** Stored velocity to cells per second, for `divergence`'s x difference. */
   divergenceX: number;
-  /** Multiplies the y difference in `divergence`. */
+  /** Stored velocity to cells per second, for `divergence`'s y difference. */
   divergenceY: number;
-  /** Multiplies the x pressure difference in `gradientSubtract`. */
+  /** Cells per second back to stored, for `gradientSubtract`'s x correction. */
   gradientX: number;
-  /** Multiplies the y pressure difference in `gradientSubtract`. */
+  /** Cells per second back to stored, for `gradientSubtract`'s y correction. */
   gradientY: number;
-  /** Weights the x neighbours in the Jacobi sweep's Laplacian. */
-  laplacianX: number;
-  /** Weights the y neighbours in the Jacobi sweep's Laplacian. */
-  laplacianY: number;
 }
 
 export const projectionScale = (
@@ -48,12 +38,6 @@ export const projectionScale = (
 ): ProjectionScale => ({
   divergenceX: width,
   divergenceY: height,
-  gradientX: width,
-  gradientY: height,
-  laplacianX: width * width,
-  laplacianY: height * height,
+  gradientX: 1 / width,
+  gradientY: 1 / height,
 });
-
-/** What the Jacobi sweep's weighted mean of the neighbours divides by. */
-export const jacobiDiagonal = (scale: ProjectionScale): number =>
-  2 * (scale.laplacianX + scale.laplacianY);

--- a/src/fluid/projection.ts
+++ b/src/fluid/projection.ts
@@ -8,16 +8,22 @@
  * what lets `projection.test.ts` check the operator identities on the CPU,
  * with no adapter.
  *
- * Velocity is stored in normalised units per second, so the canvas spans 0..1
- * on both axes and one x-unit is a different physical length from one y-unit
- * on a non-square viewport. That is where #681's anisotropy comes from — not
- * from the cells, which `fitGrid` already keeps square. Confining the metric
- * to these three passes leaves advection, the splat, and the pointer in the
- * units they already had.
+ * Velocity is stored in normalised units per second — the canvas spans 0..1 on
+ * *each* axis independently, so `vx = 1` crosses the full width in a second
+ * while `vy = 1` crosses the full height. `advect` is what fixes that reading:
+ * it converts to cell offsets by multiplying each component by that grid's own
+ * dimension, so one unit of `vx` covers `width` cells and one unit of `vy`
+ * covers `height` cells.
  *
- * Taking the canvas height as the unit of length, a cell measures `aspect /
- * width` across and `1 / height` down; every factor below follows from those
- * two lengths.
+ * Cells are square — `fitGrid` sees to that — so a cell is the natural unit of
+ * length here, and the physical speed of a velocity component is its value
+ * times the cell count along its axis. Hence the per-axis weights below: the x
+ * difference carries `width`, the y difference `height`. Summing them with
+ * equal weight, as the passes did before #681, under-counts x by the aspect
+ * ratio — 44% on a 16:9 canvas.
+ *
+ * Confining the conversion to these three passes leaves advection, the splat,
+ * and the pointer in the units they already had.
  */
 
 /** Per-axis factors the three projection passes must agree on. */
@@ -39,23 +45,14 @@ export interface ProjectionScale {
 export const projectionScale = (
   width: number,
   height: number,
-  aspect: number,
-): ProjectionScale => {
-  // Kept per-axis rather than collapsed to one `h`: rounding the cell counts
-  // to whole numbers leaves the two slightly apart, and `fitGrid`'s minimum of
-  // 2 cells drives them far apart at extreme aspects.
-  const cellX = aspect / width;
-  const cellY = 1 / height;
-
-  return {
-    divergenceX: 1 / cellX,
-    divergenceY: 1 / cellY,
-    gradientX: 1 / cellX,
-    gradientY: 1 / cellY,
-    laplacianX: 1 / (cellX * cellX),
-    laplacianY: 1 / (cellY * cellY),
-  };
-};
+): ProjectionScale => ({
+  divergenceX: width,
+  divergenceY: height,
+  gradientX: width,
+  gradientY: height,
+  laplacianX: width * width,
+  laplacianY: height * height,
+});
 
 /** What the Jacobi sweep's weighted mean of the neighbours divides by. */
 export const jacobiDiagonal = (scale: ProjectionScale): number =>

--- a/src/fluid/projection.ts
+++ b/src/fluid/projection.ts
@@ -1,0 +1,62 @@
+/**
+ * The projection's discretisation, as plain numbers.
+ *
+ * The three projection passes (`divergence`, `pressure`, `gradientSubtract`)
+ * compose into a real Helmholtz projection only if their per-axis scale
+ * factors agree. That agreement is a property of the numbers, not of any GPU
+ * state, so the numbers live here rather than inside the shader — which is
+ * what lets `projection.test.ts` check the operator identities on the CPU,
+ * with no adapter.
+ *
+ * Velocity is stored in normalised units per second, so the canvas spans 0..1
+ * on both axes and one x-unit is a different physical length from one y-unit
+ * on a non-square viewport. That is where #681's anisotropy comes from — not
+ * from the cells, which `fitGrid` already keeps square. Confining the metric
+ * to these three passes leaves advection, the splat, and the pointer in the
+ * units they already had.
+ *
+ * Taking the canvas height as the unit of length, a cell measures `aspect /
+ * width` across and `1 / height` down; every factor below follows from those
+ * two lengths.
+ */
+
+/** Per-axis factors the three projection passes must agree on. */
+export interface ProjectionScale {
+  /** Multiplies the x difference in `divergence`. */
+  divergenceX: number;
+  /** Multiplies the y difference in `divergence`. */
+  divergenceY: number;
+  /** Multiplies the x pressure difference in `gradientSubtract`. */
+  gradientX: number;
+  /** Multiplies the y pressure difference in `gradientSubtract`. */
+  gradientY: number;
+  /** Weights the x neighbours in the Jacobi sweep's Laplacian. */
+  laplacianX: number;
+  /** Weights the y neighbours in the Jacobi sweep's Laplacian. */
+  laplacianY: number;
+}
+
+export const projectionScale = (
+  width: number,
+  height: number,
+  aspect: number,
+): ProjectionScale => {
+  // Kept per-axis rather than collapsed to one `h`: rounding the cell counts
+  // to whole numbers leaves the two slightly apart, and `fitGrid`'s minimum of
+  // 2 cells drives them far apart at extreme aspects.
+  const cellX = aspect / width;
+  const cellY = 1 / height;
+
+  return {
+    divergenceX: 1 / cellX,
+    divergenceY: 1 / cellY,
+    gradientX: 1 / cellX,
+    gradientY: 1 / cellY,
+    laplacianX: 1 / (cellX * cellX),
+    laplacianY: 1 / (cellY * cellY),
+  };
+};
+
+/** What the Jacobi sweep's weighted mean of the neighbours divides by. */
+export const jacobiDiagonal = (scale: ProjectionScale): number =>
+  2 * (scale.laplacianX + scale.laplacianY);

--- a/src/fluid/projection.ts
+++ b/src/fluid/projection.ts
@@ -11,33 +11,41 @@
  * component's speed in cells is its value times the cell count along its axis.
  *
  * The conversion runs both ways and the two are reciprocal: `divergence` reads
- * stored velocity and reports a rate in cells, so it multiplies;
- * `gradientSubtract` computes a correction in cells and writes it back as
- * stored velocity, so it divides. Weighting both alike — the state this file
- * was added to fix — leaves the projection anisotropic in the correction while
- * the divergence it reports still falls, so only the written velocity reveals
- * it. The two cancel in between, which is why the Jacobi sweep inverts the
- * plain 5-point Laplacian with no weights of its own.
+ * stored velocity and reports a rate in cells; `gradientSubtract` computes a
+ * correction in cells and writes it back as stored velocity. Weighting both the
+ * same way leaves the projection anisotropic in the correction while the
+ * divergence it reports still falls — an error only the written velocity
+ * reveals, which is what the tests here are shaped around.
  */
 
-/** Per-axis factors the three projection passes must agree on. */
+/** Per-axis conversions the three projection passes must agree on. */
 export interface ProjectionScale {
-  /** Stored velocity to cells per second, for `divergence`'s x difference. */
-  divergenceX: number;
-  /** Stored velocity to cells per second, for `divergence`'s y difference. */
-  divergenceY: number;
-  /** Cells per second back to stored, for `gradientSubtract`'s x correction. */
-  gradientX: number;
-  /** Cells per second back to stored, for `gradientSubtract`'s y correction. */
-  gradientY: number;
+  /** Stored velocity to cells per second, per axis — what `divergence` reads. */
+  toCellsX: number;
+  toCellsY: number;
+  /** Cells per second back to stored, per axis — what the gradient writes. */
+  toStoredX: number;
+  toStoredY: number;
 }
 
 export const projectionScale = (
   width: number,
   height: number,
 ): ProjectionScale => ({
-  divergenceX: width,
-  divergenceY: height,
-  gradientX: 1 / width,
-  gradientY: 1 / height,
+  toCellsX: width,
+  toCellsY: height,
+  toStoredX: 1 / width,
+  toStoredY: 1 / height,
+});
+
+/**
+ * Pack the two conversions into the shader's uniform slots. Out here rather
+ * than in the renderer so a test can reach it — swapping the two reverses the
+ * metric on the GPU, and nothing reading `projectionScale` would notice.
+ */
+export const projectionUniform = (
+  scale: ProjectionScale,
+): { toCells: [number, number]; toStored: [number, number] } => ({
+  toCells: [scale.toCellsX, scale.toCellsY],
+  toStored: [scale.toStoredX, scale.toStoredY],
 });

--- a/src/fluid/renderer.ts
+++ b/src/fluid/renderer.ts
@@ -9,7 +9,7 @@ import {
   WORKGROUP_SIZE,
 } from "./config";
 import type { ProjectionScale } from "./projection";
-import { jacobiDiagonal, projectionScale } from "./projection";
+import { projectionScale } from "./projection";
 import renderShaderSource from "./render.wgsl?raw";
 import simulationShaderSource from "./simulation.wgsl?raw";
 import type { FluidRenderer, Pointer } from "./types";
@@ -25,15 +25,11 @@ const UNIFORM = {
   splatRadius: 13,
   splatActive: 14,
   aspect: 15,
-  // `divergence` and `gradientSubtract` share one pair: both differentiate
-  // once, so both scale by the reciprocal cell size. `projection.test.ts`
-  // asserts they stay equal.
-  differenceScale: 16,
-  laplacianScale: 18,
-  jacobiDiagonal: 20,
+  toCells: 16,
+  toStored: 18,
 } as const;
 
-const UNIFORM_FLOATS = 24;
+const UNIFORM_FLOATS = 20;
 const UNIFORM_BYTES = UNIFORM_FLOATS * 4;
 
 const PARAM_BYTES = 16;
@@ -456,15 +452,8 @@ export const createFluidRenderer = (
     uniformData[UNIFORM.splatRadius] = SPLAT_RADIUS;
     uniformData[UNIFORM.splatActive] = pointer.down ? 1 : 0;
     uniformData[UNIFORM.aspect] = dyeGrid.width / dyeGrid.height;
-    uniformData.set(
-      [scale.divergenceX, scale.divergenceY],
-      UNIFORM.differenceScale,
-    );
-    uniformData.set(
-      [scale.laplacianX, scale.laplacianY],
-      UNIFORM.laplacianScale,
-    );
-    uniformData[UNIFORM.jacobiDiagonal] = jacobiDiagonal(scale);
+    uniformData.set([scale.divergenceX, scale.divergenceY], UNIFORM.toCells);
+    uniformData.set([scale.gradientX, scale.gradientY], UNIFORM.toStored);
 
     device.queue.writeBuffer(uniformBuffer, 0, uniformData);
 

--- a/src/fluid/renderer.ts
+++ b/src/fluid/renderer.ts
@@ -8,6 +8,8 @@ import {
   VELOCITY_DISSIPATION,
   WORKGROUP_SIZE,
 } from "./config";
+import type { ProjectionScale } from "./projection";
+import { jacobiDiagonal, projectionScale } from "./projection";
 import renderShaderSource from "./render.wgsl?raw";
 import simulationShaderSource from "./simulation.wgsl?raw";
 import type { FluidRenderer, Pointer } from "./types";
@@ -23,9 +25,15 @@ const UNIFORM = {
   splatRadius: 13,
   splatActive: 14,
   aspect: 15,
+  // `divergence` and `gradientSubtract` share one pair: both differentiate
+  // once, so both scale by the reciprocal cell size. `projection.test.ts`
+  // asserts they stay equal.
+  differenceScale: 16,
+  laplacianScale: 18,
+  jacobiDiagonal: 20,
 } as const;
 
-const UNIFORM_FLOATS = 16;
+const UNIFORM_FLOATS = 24;
 const UNIFORM_BYTES = UNIFORM_FLOATS * 4;
 
 const PARAM_BYTES = 16;
@@ -235,6 +243,8 @@ export const createFluidRenderer = (
   interface Resources {
     simGrid: Grid;
     dyeGrid: Grid;
+    /** Fixed by the grid and the canvas, so resolved once per resize. */
+    scale: ProjectionScale;
     velocity: DoubleBuffer;
     dye: DoubleBuffer;
     pressure: DoubleBuffer;
@@ -260,6 +270,7 @@ export const createFluidRenderer = (
   ): Resources => {
     const simGrid = fitGrid(canvasWidth, canvasHeight, SIM_RESOLUTION);
     const dyeGrid = fitGrid(canvasWidth, canvasHeight, DYE_RESOLUTION);
+    const scale = projectionScale(simGrid.width, simGrid.height);
 
     const velocity = new DoubleBuffer(device, simGrid, VELOCITY_FORMAT);
     const dye = new DoubleBuffer(device, dyeGrid, DYE_FORMAT);
@@ -394,6 +405,7 @@ export const createFluidRenderer = (
     return {
       simGrid,
       dyeGrid,
+      scale,
       velocity,
       dye,
       pressure,
@@ -434,7 +446,7 @@ export const createFluidRenderer = (
     const current = resources;
     if (current === null) return;
 
-    const { simGrid, dyeGrid, velocity, dye, pressure } = current;
+    const { simGrid, dyeGrid, scale, velocity, dye, pressure } = current;
 
     uniformData.set([simGrid.width, simGrid.height], UNIFORM.simSize);
     uniformData.set([pointer.x, pointer.y], UNIFORM.splatPoint);
@@ -444,6 +456,15 @@ export const createFluidRenderer = (
     uniformData[UNIFORM.splatRadius] = SPLAT_RADIUS;
     uniformData[UNIFORM.splatActive] = pointer.down ? 1 : 0;
     uniformData[UNIFORM.aspect] = dyeGrid.width / dyeGrid.height;
+    uniformData.set(
+      [scale.divergenceX, scale.divergenceY],
+      UNIFORM.differenceScale,
+    );
+    uniformData.set(
+      [scale.laplacianX, scale.laplacianY],
+      UNIFORM.laplacianScale,
+    );
+    uniformData[UNIFORM.jacobiDiagonal] = jacobiDiagonal(scale);
 
     device.queue.writeBuffer(uniformBuffer, 0, uniformData);
 

--- a/src/fluid/renderer.ts
+++ b/src/fluid/renderer.ts
@@ -9,7 +9,7 @@ import {
   WORKGROUP_SIZE,
 } from "./config";
 import type { ProjectionScale } from "./projection";
-import { projectionScale } from "./projection";
+import { projectionScale, projectionUniform } from "./projection";
 import renderShaderSource from "./render.wgsl?raw";
 import simulationShaderSource from "./simulation.wgsl?raw";
 import type { FluidRenderer, Pointer } from "./types";
@@ -452,8 +452,9 @@ export const createFluidRenderer = (
     uniformData[UNIFORM.splatRadius] = SPLAT_RADIUS;
     uniformData[UNIFORM.splatActive] = pointer.down ? 1 : 0;
     uniformData[UNIFORM.aspect] = dyeGrid.width / dyeGrid.height;
-    uniformData.set([scale.divergenceX, scale.divergenceY], UNIFORM.toCells);
-    uniformData.set([scale.gradientX, scale.gradientY], UNIFORM.toStored);
+    const metric = projectionUniform(scale);
+    uniformData.set(metric.toCells, UNIFORM.toCells);
+    uniformData.set(metric.toStored, UNIFORM.toStored);
 
     device.queue.writeBuffer(uniformBuffer, 0, uniformData);
 

--- a/src/fluid/simulation.wgsl
+++ b/src/fluid/simulation.wgsl
@@ -17,6 +17,11 @@ struct Uniforms {
   splatRadius: f32,    // divides squared distance, so a squared length
   splatActive: f32,    // 1 when there is input to splat, 0 otherwise
   aspect: f32,         // width / height, keeps splats circular
+  // The projection's metric, derived host-side in `projection.ts` so the three
+  // passes below cannot drift apart — see that file for what each one means.
+  differenceScale: vec2f,
+  laplacianScale: vec2f,
+  jacobiDiagonal: f32,
 }
 
 @group(0) @binding(0) var<uniform> u: Uniforms;
@@ -111,7 +116,10 @@ fn divergence(@builtin(global_invocation_id) gid: vec3u) {
   if (gid.y == 0u) { down = -centre.y; }
   if (gid.y == size.y - 1u) { up = -centre.y; }
 
-  textureStore(divergenceOutput, gid.xy, vec4f(0.5 * (right - left + up - down), 0.0, 0.0, 1.0));
+  let divergenceValue =
+    0.5 * u.differenceScale.x * (right - left) +
+    0.5 * u.differenceScale.y * (up - down);
+  textureStore(divergenceOutput, gid.xy, vec4f(divergenceValue, 0.0, 0.0, 1.0));
 }
 
 // ------------------------------------------------------------------ pressure
@@ -133,7 +141,11 @@ fn pressure(@builtin(global_invocation_id) gid: vec3u) {
   let up = sampleAt(pressureInput, u.simSize, cell + vec2f(0.0, 1.0)).x;
   let divergenceValue = sampleAt(pressureDivergence, u.simSize, cell).x;
 
-  let next = (left + right + down + up - divergenceValue) * 0.25;
+  // Each axis carries its own cell size, so the neighbours are a weighted mean
+  // rather than a plain average and the divisor is no longer a constant 4.
+  let neighbours =
+    u.laplacianScale.x * (left + right) + u.laplacianScale.y * (down + up);
+  let next = (neighbours - divergenceValue) / u.jacobiDiagonal;
   textureStore(pressureOutput, gid.xy, vec4f(next, 0.0, 0.0, 1.0));
 }
 
@@ -156,7 +168,8 @@ fn gradientSubtract(@builtin(global_invocation_id) gid: vec3u) {
   let up = sampleAt(gradientPressure, u.simSize, cell + vec2f(0.0, 1.0)).x;
 
   let velocity = sampleAt(gradientVelocity, u.simSize, cell).xy;
-  let projected = velocity - 0.5 * vec2f(right - left, up - down);
+  let gradient = 0.5 * u.differenceScale * vec2f(right - left, up - down);
+  let projected = velocity - gradient;
   let bounded = projected * velocityBoundaryScale(gid.xy, size);
 
   textureStore(gradientOutput, gid.xy, vec4f(bounded, 0.0, 1.0));

--- a/src/fluid/simulation.wgsl
+++ b/src/fluid/simulation.wgsl
@@ -11,7 +11,7 @@
 struct Uniforms {
   simSize: vec2f,      // velocity grid, in cells
   splatPoint: vec2f,   // normalised 0..1, origin top-left
-  splatDelta: vec2f,   // pointer motion, normalised units per second
+  splatDelta: vec2f,   // pointer travel since the last frame, times SPLAT_FORCE
   splatColor: vec4f,
   dt: f32,
   splatRadius: f32,    // divides squared distance, so a squared length
@@ -48,14 +48,14 @@ fn sampleAt(tex: texture_2d<f32>, size: vec2f, cell: vec2f) -> vec4f {
   return mix(mix(c00, c10, frac.x), mix(c01, c11, frac.x), frac.y);
 }
 
-/// Free-slip walls: the boundary cell mirrors its inward neighbour with the
-/// normal component negated, so fluid slides along the edge instead of
-/// leaking through it.
-fn velocityBoundaryScale(id: vec2u, size: vec2u) -> vec2f {
-  var scale = vec2f(1.0, 1.0);
-  if (id.x == 0u || id.x == size.x - 1u) { scale.x = -1.0; }
-  if (id.y == 0u || id.y == size.y - 1u) { scale.y = -1.0; }
-  return scale;
+/// Free-slip walls: no flow crosses the edge, so the component normal to it is
+/// dropped while the tangential one slides along untouched. Negating the normal
+/// component instead would keep its magnitude and merely reverse the leak.
+fn applyVelocityBoundary(velocity: vec2f, id: vec2u, size: vec2u) -> vec2f {
+  var bounded = velocity;
+  if (id.x == 0u || id.x == size.x - 1u) { bounded.x = 0.0; }
+  if (id.y == 0u || id.y == size.y - 1u) { bounded.y = 0.0; }
+  return bounded;
 }
 
 // ---------------------------------------------------------------- advection
@@ -170,7 +170,7 @@ fn gradientSubtract(@builtin(global_invocation_id) gid: vec3u) {
   let velocity = sampleAt(gradientVelocity, u.simSize, cell).xy;
   let gradient = 0.5 * u.differenceScale * vec2f(right - left, up - down);
   let projected = velocity - gradient;
-  let bounded = projected * velocityBoundaryScale(gid.xy, size);
+  let bounded = applyVelocityBoundary(projected, gid.xy, size);
 
   textureStore(gradientOutput, gid.xy, vec4f(bounded, 0.0, 1.0));
 }

--- a/src/fluid/simulation.wgsl
+++ b/src/fluid/simulation.wgsl
@@ -7,21 +7,25 @@
 // `Uniforms` is padded to 16-byte alignment by hand and holds no vec3: vec3
 // padding in a host-shared struct is driver-fragile, so every field is either
 // a scalar or a vec4.
+//
+// The three projection passes have a hand-written CPU twin in
+// `projection.test.ts`, which is where their arithmetic is actually checked —
+// editing one of them means editing it there too.
 
 struct Uniforms {
   simSize: vec2f,      // velocity grid, in cells
   splatPoint: vec2f,   // normalised 0..1, origin top-left
-  splatDelta: vec2f,   // pointer travel since the last frame, times SPLAT_FORCE
+  splatDelta: vec2f,   // pointer travel this frame x SPLAT_FORCE, not a rate
   splatColor: vec4f,
   dt: f32,
   splatRadius: f32,    // divides squared distance, so a squared length
   splatActive: f32,    // 1 when there is input to splat, 0 otherwise
   aspect: f32,         // width / height, keeps splats circular
-  // The projection's metric, derived host-side in `projection.ts` so the three
-  // passes below cannot drift apart — see that file for what each one means.
-  differenceScale: vec2f,
-  laplacianScale: vec2f,
-  jacobiDiagonal: f32,
+  // The projection's metric, derived host-side in `projection.ts`. The two are
+  // reciprocals — stored velocity to cells per second and back — so they cancel
+  // across the solve and the Jacobi sweep needs no weights of its own.
+  toCells: vec2f,
+  toStored: vec2f,
 }
 
 @group(0) @binding(0) var<uniform> u: Uniforms;
@@ -117,8 +121,7 @@ fn divergence(@builtin(global_invocation_id) gid: vec3u) {
   if (gid.y == size.y - 1u) { up = -centre.y; }
 
   let divergenceValue =
-    0.5 * u.differenceScale.x * (right - left) +
-    0.5 * u.differenceScale.y * (up - down);
+    0.5 * u.toCells.x * (right - left) + 0.5 * u.toCells.y * (up - down);
   textureStore(divergenceOutput, gid.xy, vec4f(divergenceValue, 0.0, 0.0, 1.0));
 }
 
@@ -141,11 +144,7 @@ fn pressure(@builtin(global_invocation_id) gid: vec3u) {
   let up = sampleAt(pressureInput, u.simSize, cell + vec2f(0.0, 1.0)).x;
   let divergenceValue = sampleAt(pressureDivergence, u.simSize, cell).x;
 
-  // Each axis carries its own cell size, so the neighbours are a weighted mean
-  // rather than a plain average and the divisor is no longer a constant 4.
-  let neighbours =
-    u.laplacianScale.x * (left + right) + u.laplacianScale.y * (down + up);
-  let next = (neighbours - divergenceValue) / u.jacobiDiagonal;
+  let next = (left + right + down + up - divergenceValue) * 0.25;
   textureStore(pressureOutput, gid.xy, vec4f(next, 0.0, 0.0, 1.0));
 }
 
@@ -168,7 +167,7 @@ fn gradientSubtract(@builtin(global_invocation_id) gid: vec3u) {
   let up = sampleAt(gradientPressure, u.simSize, cell + vec2f(0.0, 1.0)).x;
 
   let velocity = sampleAt(gradientVelocity, u.simSize, cell).xy;
-  let gradient = 0.5 * u.differenceScale * vec2f(right - left, up - down);
+  let gradient = 0.5 * u.toStored * vec2f(right - left, up - down);
   let projected = velocity - gradient;
   let bounded = applyVelocityBoundary(projected, gid.xy, size);
 

--- a/src/fluid/types.ts
+++ b/src/fluid/types.ts
@@ -2,9 +2,9 @@ export interface Pointer {
   /** Normalised position, origin top-left. */
   x: number;
   y: number;
-  /** Normalised travel accumulated since the last frame, scaled by
-   * `SPLAT_FORCE`. Not a rate: it is never divided by elapsed time, so a given
-   * drag deposits the same impulse however long the frame took. */
+  /** Normalised travel accumulated since the last `consume`, scaled by
+   * `SPLAT_FORCE` — a displacement, not a rate; nothing divides it by elapsed
+   * time. */
   dx: number;
   dy: number;
   down: boolean;

--- a/src/fluid/types.ts
+++ b/src/fluid/types.ts
@@ -2,7 +2,9 @@ export interface Pointer {
   /** Normalised position, origin top-left. */
   x: number;
   y: number;
-  /** Motion since the previous frame, in normalised units per second. */
+  /** Normalised travel accumulated since the last frame, scaled by
+   * `SPLAT_FORCE`. Not a rate: it is never divided by elapsed time, so a given
+   * drag deposits the same impulse however long the frame took. */
   dx: number;
   dy: number;
   down: boolean;


### PR DESCRIPTION
Fixes the anisotropic projection reported in #681, and adds the harness that
makes claims about the projection checkable. The stencil mismatch — the issue's
second defect — is left open, with a measurement recorded for why.

## What changed

**The projection was anisotropic on any non-square viewport.** `divergence`
summed its two axes with equal weight, but they do not carry the same units:
velocity is stored normalised per axis, so `vx = 1` crosses the full canvas
width in a second while `vy = 1` crosses the full height, and `advect` reads it
that way. On the 320x180 grid a 16:9 canvas produces, that makes a unit of `vx`
320 cells per second against 180 for `vy` — weighting the differences equally
under-counts x by 44%.

Each pass now carries the conversion for its own axis. The two directions are
reciprocal: `divergence` reads stored velocity and reports a rate in cells, so
it multiplies by the cell count; `gradientSubtract` computes its correction in
cells and writes it back as stored velocity, so it divides. They cancel in
between, which is why the Jacobi sweep is unchanged.

**The free-slip wall was reversing the flow it should have blocked.**
`velocityBoundaryScale` negated the velocity at each boundary cell, which keeps
its magnitude and only turns the leak around — fluid arriving at a wall left it
again at the same speed. It also ran after the gradient subtraction, undoing
part of the solve. It now drops the normal component and leaves the tangential
one alone. Its comment had described a third thing again (mirroring the inward
neighbour), which the code never did.

**Unit comments that were wrong.** `splatDelta` was documented as normalised
units per second in two places; nothing divides it by elapsed time.

## Impact

Visible on any non-square viewport, which is nearly all of them — the fluid's
response to a drag was direction-dependent and is no longer. Square viewports
are unaffected by the metric change. The wall fix changes behaviour everywhere,
in the interior as well as at the edges, since the projection is no longer
partly undone after it runs.

`src/fluid/config.ts` is untouched. The velocity's units are unchanged, so the
empirical constants keep their meaning; nothing in the measurements suggested
one had drifted far enough to want moving.

## Why the stencil mismatch is still open

`divergence` and `gradientSubtract` use central differences while the Jacobi
sweep solves a 1-cell Laplacian, so the sweep does not invert the operator whose
divergence it is given. Real, but measured at the grid size actually used — and
letting the pressure field carry over between frames, as it does on the GPU —
matching the stencils lands within a tenth of a point of the current scheme
however long it runs. Doing it properly means moving the velocity components
onto cell faces, which advection and the splat would have to follow. That is a
larger change with no measured payoff here, so it stays in #681 with the numbers
attached.

## Verification

The solver had no unit tests: the shaders need a GPU adapter, and the Playwright
suite only asserts that pixels light up and keep changing — it passes just as
happily with a wrong sign, a swapped axis, or a conversion applied backwards.

`src/fluid/projection.ts` holds the metric as plain numbers so
`projection.test.ts` can rebuild the operators on the CPU and check the
identities they have to satisfy. Verified by mutation — 12 corruptions, each
failing at least one assertion: reversing either conversion, swapping either
pair of axes, flipping either sign, dropping either wall's normal component,
negating instead of zeroing at a wall, a wrong Jacobi constant, and swapping or
duplicating a uniform slot.

Three things the harness caught that would otherwise have shipped, each of which
the Playwright suite passes:

- The gradient's direction. The first version of this branch weighted both
  passes the same way, which moves the anisotropy into the correction instead of
  removing it — and since the divergence such a pass reports still falls, only a
  test that measures what the pass *writes* sees it. Measured on a curl-free
  field at 64x32: 2.2% of it survives the wrong version against 0.9% for the
  right one, and on a square grid the two agree exactly.
- A wall regression on one axis. The wall test only exercised `vy`, so deleting
  the vertical wall's branch outright left everything passing.
- A swap of the two uniform writes. They live in `renderer.ts`, which needs a
  GPU device and is excluded from the suite, and the two values are reciprocals
  — so swapping them is a metric that looks valid everywhere except on the GPU.
  Moved into `projectionUniform` where a test can reach it.

## Test plan

CI runs type-check, lint, unit tests, and the Playwright suite; all pass.
Nothing here needs manual verification beyond that — the E2E suite exercises the
changed shader against the production build on a real adapter.

