### PR TITLE
docs: describe the setup that lefthook actually needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ here than broad reach.
 
 ## Getting Started
 
-- [mise](https://mise.jdx.dev/) provisions Node.js, pnpm, and `hk` at the
-  versions pinned in `mise.toml`.
+- [mise](https://mise.jdx.dev/) provisions Node.js and pnpm at the versions
+  pinned in `mise.toml`.
 
 ```bash
 mise install
@@ -25,9 +25,10 @@ pnpm install
 pnpm dev
 ```
 
-`mise install` has to come first: `pnpm install` runs `hk install` in its
-`prepare` script, and without the toolchain on your `PATH` it aborts with
-`hk: command not found`.
+`mise install` has to come first because pnpm itself comes from mise; there is
+no other step here that needs it. Git hooks are installed by `pnpm install`
+through its `prepare` script, which runs the `lefthook` binary out of
+`node_modules`, so they need nothing on your `PATH`.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,9 @@ pnpm install
 pnpm dev
 ```
 
-`mise install` has to come first because pnpm itself comes from mise; there is
-no other step here that needs it. Git hooks are installed by `pnpm install`
-through its `prepare` script, which runs the `lefthook` binary out of
-`node_modules`, so they need nothing on your `PATH`.
+`mise install` has to come first: everything after it runs on the Node.js and
+pnpm it puts on your `PATH`. Git hooks install themselves as part of
+`pnpm install`.
 
 ## How it works
 


### PR DESCRIPTION
#684 replaced hk with lefthook and did not carry the change into README, so the
setup section still described the tooling that was removed.

## What was wrong

- **"mise provisions Node.js, pnpm, and `hk`"** — `mise.toml` lists node and
  pnpm. #684 removed the `hk` entry.
- **"`pnpm install` runs `hk install` in its `prepare` script"** — the
  `prepare` script is `lefthook install`.
- **"without the toolchain on your `PATH` it aborts with `hk: command not
  found`"** — named a binary that is no longer involved.

## What it says now

```
`mise install` has to come first: everything after it runs on the Node.js and
pnpm it puts on your `PATH`. Git hooks install themselves as part of
`pnpm install`.
```

The prescribed order is unchanged and still correct. The reason given for it is
new, and broader than the old one: every step after `mise install` runs on the
Node.js it provides, not just pnpm. `node_modules/.bin/lefthook` and
`node_modules/.bin/vite` are both shell shims that `exec node` from `PATH`, and
the mise-installed `pnpm` is itself a `#!/usr/bin/env node` script:

```
$ env -i PATH=/usr/bin:/bin ./node_modules/.bin/lefthook version
./node_modules/.bin/lefthook: line 41: exec: node: not found
```

The old paragraph's account of *how* hooks resolve is dropped rather than
rewritten. A reader following three commands does not ask that, and it is the
kind of explanation that went stale the moment the hooks tooling changed —
which is what put this PR here.

## Review note

The first version of this branch replaced the wrong explanation with another
wrong one: it claimed pnpm was the only thing here coming from mise, and that
hooks "need nothing on your `PATH`" because lefthook resolves out of
`node_modules`. Both false, and the second false for the same reason as the
first. Three reviewers flagged it independently, one of them by running the
command above. Fixed in the second commit; the reproduction is what the current
text is written against.

## Test plan

CI runs type-check, lint, Prettier, unit tests, and the Playwright suite.
Nothing here needs manual verification beyond that — the change is prose, and
the claims it makes were checked by reproduction rather than by reading.
