### PR TITLE
docs: describe the lefthook setup, not hk

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ here than broad reach.
 
 ## Getting Started
 
-- [mise](https://mise.jdx.dev/) provisions Node.js, pnpm, and `hk` at the
-  versions pinned in `mise.toml`.
+- [mise](https://mise.jdx.dev/) provisions Node.js and pnpm at the versions
+  pinned in `mise.toml`.
 
 ```bash
 mise install
@@ -25,9 +25,9 @@ pnpm install
 pnpm dev
 ```
 
-`mise install` has to come first: `pnpm install` runs `hk install` in its
-`prepare` script, and without the toolchain on your `PATH` it aborts with
-`hk: command not found`.
+`mise install` has to come first: `pnpm install` needs the pinned Node.js and
+pnpm on your `PATH`. Its `prepare` script then runs `lefthook install`, which
+sets up the git hooks.
 
 ## How it works
 


### PR DESCRIPTION
## What

Updates two README spots that still described `hk`.

## Why

#684 replaced hk with lefthook. The prerequisites still listed `hk` among the tools mise provisions, and the setup note still warned that skipping `mise install` aborts with `hk: command not found` — a failure that can no longer happen, since lefthook comes from `node_modules` rather than the toolchain.

## Test plan

- [x] `prettier --check README.md`
- [x] No remaining `hk` references in the README