### PR TITLE
refactor: give the splat uniforms their own bind group

### DIFF
--- a/src/fluid/renderer.ts
+++ b/src/fluid/renderer.ts
@@ -154,8 +154,18 @@ export const createFluidRenderer = (
         visibility: GPUShaderStage.COMPUTE,
         buffer: { type: "uniform" },
       },
+    ],
+  });
+
+  const sharedBindGroup = device.createBindGroup({
+    layout: sharedLayout,
+    entries: [{ binding: 0, resource: { buffer: uniformBuffer } }],
+  });
+
+  const splatUniformLayout = device.createBindGroupLayout({
+    entries: [
       {
-        binding: 1,
+        binding: 0,
         visibility: GPUShaderStage.COMPUTE,
         buffer: {
           type: "uniform",
@@ -166,16 +176,12 @@ export const createFluidRenderer = (
     ],
   });
 
-  const sharedBindGroup = device.createBindGroup({
-    layout: sharedLayout,
+  const splatUniformBindGroup = device.createBindGroup({
+    layout: splatUniformLayout,
     entries: [
-      { binding: 0, resource: { buffer: uniformBuffer } },
       {
-        binding: 1,
-        resource: {
-          buffer: splatBuffer,
-          size: SPLAT_UNIFORM_FLOATS * 4,
-        },
+        binding: 0,
+        resource: { buffer: splatBuffer, size: SPLAT_UNIFORM_FLOATS * 4 },
       },
     ],
   });
@@ -218,11 +224,15 @@ export const createFluidRenderer = (
   const computePipeline = (
     entryPoint: string,
     passLayout: GPUBindGroupLayout,
+    splatUniforms?: GPUBindGroupLayout,
   ): GPUComputePipeline =>
     device.createComputePipeline({
       label: entryPoint,
       layout: device.createPipelineLayout({
-        bindGroupLayouts: [sharedLayout, passLayout],
+        bindGroupLayouts:
+          splatUniforms === undefined
+            ? [sharedLayout, passLayout]
+            : [sharedLayout, passLayout, splatUniforms],
       }),
       compute: { module: simulationModule, entryPoint },
     });
@@ -232,7 +242,7 @@ export const createFluidRenderer = (
     divergence: computePipeline("divergence", divergenceLayout),
     pressure: computePipeline("pressure", pressureLayout),
     gradientSubtract: computePipeline("gradientSubtract", gradientLayout),
-    splat: computePipeline("splat", splatLayout),
+    splat: computePipeline("splat", splatLayout, splatUniformLayout),
   };
 
   const renderLayout = device.createBindGroupLayout({
@@ -506,7 +516,7 @@ export const createFluidRenderer = (
 
     const encoder = device.createCommandEncoder();
     const pass = encoder.beginComputePass();
-    pass.setBindGroup(0, sharedBindGroup, [0]);
+    pass.setBindGroup(0, sharedBindGroup);
 
     const simDispatch = dispatchSize(simGrid);
     const dyeDispatch = dispatchSize(dyeGrid);
@@ -533,7 +543,7 @@ export const createFluidRenderer = (
     // both grids, so the frame's cost grows with their count — the seed burst
     // is deliberately a one-off.
     applied.forEach((_, index) => {
-      pass.setBindGroup(0, sharedBindGroup, [index * splatSlotBytes]);
+      pass.setBindGroup(2, splatUniformBindGroup, [index * splatSlotBytes]);
 
       run(
         pipelines.splat,

--- a/src/fluid/simulation.wgsl
+++ b/src/fluid/simulation.wgsl
@@ -23,21 +23,7 @@ struct Uniforms {
   toStored: vec2f,
 }
 
-/// One splat's own parameters. Separate from `Uniforms` because a frame injects
-/// any number of splats — each dispatch selects its own slot by dynamic offset,
-/// so they cannot be folded into the per-frame block.
-struct SplatUniforms {
-  point: vec2f,        // normalised 0..1, origin top-left
-  delta: vec2f,        // a displacement rather than a rate
-  color: vec4f,
-  radius: f32,         // divides squared distance, so a squared length
-  _pad0: f32,
-  _pad1: f32,
-  _pad2: f32,
-}
-
 @group(0) @binding(0) var<uniform> u: Uniforms;
-@group(0) @binding(1) var<uniform> s: SplatUniforms;
 
 /// Read one texel, clamping to the edge so out-of-range reads mirror the
 /// wall's value rather than wrapping to the far side of the grid.
@@ -191,9 +177,25 @@ struct SplatParams {
   _pad: f32,
 }
 
+/// One splat's own parameters. Separate from `Uniforms` because a frame injects
+/// any number of splats — each dispatch selects its own slot by dynamic offset,
+/// so they cannot be folded into the per-frame block.
+struct SplatUniforms {
+  point: vec2f,        // normalised 0..1, origin top-left
+  delta: vec2f,        // a displacement rather than a rate
+  color: vec4f,
+  radius: f32,         // divides squared distance, so a squared length
+  _pad0: f32,
+  _pad1: f32,
+  _pad2: f32,
+}
+
 @group(1) @binding(0) var splatSource: texture_2d<f32>;
 @group(1) @binding(1) var splatOutput: texture_storage_2d<rgba32float, write>;
 @group(1) @binding(2) var<uniform> splatParams: SplatParams;
+
+// Its own group, so the passes that never read a splat are not made to bind one.
+@group(2) @binding(0) var<uniform> s: SplatUniforms;
 
 /// Add a gaussian blob of force or colour at the splat's point.
 @compute @workgroup_size(WORKGROUP_SIZE, WORKGROUP_SIZE)


### PR DESCRIPTION
The splat parameters rode in group 0 next to the per-frame uniforms. Because
they are selected by dynamic offset, that meant every pass — advection, the
whole pressure solve, the gradient subtract — had to bind an offset it never
reads, and after the splat loop the last splat's offset stayed bound for
everything downstream.

Nothing else reads `s`, so this changed no output. It is the next pass to read
it that would have picked up whichever slot happened to be left over.

Group 2 is declared by the splat pipeline alone, so the offset is now set where
it is read and nowhere else.

## Test plan

Nothing beyond CI. Bind-group changes are validated by the GPU rather than by
the type checker, so the e2e suite is what covers this — it drives the real
pipeline and would surface a validation error as a failed run. Also checked
locally that the page raises no console errors or warnings during startup and a
drag, which a wrong binding would produce.
