### PR TITLE
Settings: expose grid resolution, carrying the fields across the rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Real-time fluid simulation filling the browser viewport, solved entirely on the
 GPU with [WebGPU](https://www.w3.org/TR/webgpu/) compute shaders. It opens
 mid-motion and settles as the dye dissipates; drag anywhere to stir it. A panel
 behind the gear in the corner tunes the solver live — decay rates, splat size
-and force, pressure sweeps — and remembers what you set.
+and force, pressure sweeps, and the grid resolutions — and remembers what you
+set.
 
 Built with React + Vite and deployed to
 [Cloudflare Workers](https://workers.cloudflare.com/) as static assets.

--- a/e2e-tests/index.spec.ts
+++ b/e2e-tests/index.spec.ts
@@ -40,7 +40,6 @@ const hideSettings = async (page: Page, hidden = true): Promise<void> => {
   }, hidden);
 };
 
-/** Hides the panel only for the read, so a test can keep driving it afterwards. */
 const whileHidden = async <T>(
   page: Page,
   read: () => Promise<T>,
@@ -242,7 +241,7 @@ test.describe("fluid canvas", () => {
     expect(fast).toBeLessThan(0.2);
   });
 
-  test("carries the dye across a resolution change instead of blanking it", async ({
+  test("carries both fields across a resolution change instead of blanking them", async ({
     page,
   }) => {
     // Raised because each canvas read is a screenshot, which costs seconds
@@ -277,6 +276,15 @@ test.describe("fluid canvas", () => {
     // here; the resample pass is the only thing that keeps the dye.
     const after = await whileHidden(page, () => meanBrightness(page));
     expect(after).toBeGreaterThan(before * 0.5);
+
+    // Brightness cannot see the velocity half of the carry — dropping it freezes
+    // the fluid with every lit pixel in place; only motion shows it survived.
+    const changed = await whileHidden(page, async () => {
+      const first = await sampleCanvas(page);
+      const second = await sampleCanvas(page);
+      return meanChange(first, second);
+    });
+    expect(changed).toBeGreaterThan(0.002);
   });
 
   test("restores a changed resolution after a reload", async ({ page }) => {

--- a/e2e-tests/index.spec.ts
+++ b/e2e-tests/index.spec.ts
@@ -28,8 +28,41 @@ const SAMPLE_WIDTH = 64;
 
 /** The settings toggle sits over the canvas, and an element screenshot
  * composites it in — its lit corner otherwise counts as dye. */
-const hideSettings = async (page: Page): Promise<void> => {
-  await page.addStyleTag({ content: ".settings { display: none; }" });
+const hideSettings = async (page: Page, hidden = true): Promise<void> => {
+  await page.evaluate((on) => {
+    const id = "e2e-hide-settings";
+    document.getElementById(id)?.remove();
+    if (!on) return;
+    const style = document.createElement("style");
+    style.id = id;
+    style.textContent = ".settings { display: none; }";
+    document.head.append(style);
+  }, hidden);
+};
+
+/** Hides the panel only for the read, so a test can keep driving it afterwards. */
+const whileHidden = async <T>(
+  page: Page,
+  read: () => Promise<T>,
+): Promise<T> => {
+  await hideSettings(page);
+  try {
+    return await read();
+  } finally {
+    await hideSettings(page, false);
+  }
+};
+
+/** Blurs as well as fills, because a resolution row reports its value on
+ * release: `fill` alone leaves the panel treating the drag as still in hand. */
+const settleSlider = async (
+  page: Page,
+  name: string,
+  value: string,
+): Promise<void> => {
+  const slider = page.getByRole("slider", { name });
+  await slider.fill(value);
+  await slider.blur();
 };
 
 /** Read through a screenshot because a WebGPU canvas does not preserve its
@@ -117,7 +150,7 @@ test.describe("fluid canvas", () => {
     await page.getByRole("button", { name: "Open settings" }).click();
 
     await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
-    await expect(page.getByRole("slider")).toHaveCount(5);
+    await expect(page.getByRole("slider")).toHaveCount(7);
   });
 
   test("restores a changed setting after a reload, and drops it on reset", async ({
@@ -207,6 +240,70 @@ test.describe("fluid canvas", () => {
 
     expect(slow).toBeGreaterThan(0.5);
     expect(fast).toBeLessThan(0.2);
+  });
+
+  test("carries the dye across a resolution change instead of blanking it", async ({
+    page,
+  }) => {
+    // Raised because each canvas read is a screenshot, which costs seconds
+    // against CI's software renderer — the default 30s ceiling is not enough.
+    test.setTimeout(180_000);
+
+    await page.goto("/?seed=off");
+    await page.evaluate(() => {
+      window.localStorage.clear();
+    });
+    await page.goto("/?seed=off");
+    await expect(page.getByRole("alert")).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Open settings" }).click();
+    // Held still so the reads either side of the rebuild differ by the rebuild
+    // and not by however long the screenshots took.
+    await page.getByRole("slider", { name: "Dye decay" }).fill("0");
+
+    const viewport = page.viewportSize() ?? { width: 1280, height: 720 };
+    await stir(page, viewport);
+
+    const before = await whileHidden(page, () => meanBrightness(page));
+    expect(before).toBeGreaterThan(0);
+
+    await settleSlider(page, "Sim grid", "128");
+    await settleSlider(page, "Dye grid", "512");
+    await page.evaluate(
+      () => new Promise((resolve) => requestAnimationFrame(resolve)),
+    );
+
+    // Releasing the old textures before building the new ones would read as 0
+    // here; the resample pass is the only thing that keeps the dye.
+    const after = await whileHidden(page, () => meanBrightness(page));
+    expect(after).toBeGreaterThan(before * 0.5);
+  });
+
+  test("restores a changed resolution after a reload", async ({ page }) => {
+    await page.goto("/");
+    await page.evaluate(() => {
+      window.localStorage.clear();
+    });
+    await page.goto("/");
+    await page.getByRole("button", { name: "Open settings" }).click();
+
+    const initial = await page
+      .getByRole("slider", { name: "Sim grid" })
+      .inputValue();
+    await settleSlider(page, "Sim grid", "160");
+
+    await page.reload();
+    await page.getByRole("button", { name: "Open settings" }).click();
+    await expect(page.getByRole("slider", { name: "Sim grid" })).toHaveValue(
+      "160",
+    );
+
+    await page.getByRole("button", { name: "Reset" }).click();
+    await page.reload();
+    await page.getByRole("button", { name: "Open settings" }).click();
+    await expect(page.getByRole("slider", { name: "Sim grid" })).toHaveValue(
+      initial,
+    );
   });
 
   test("starts the GPU simulation and paints dye where the pointer drags", async ({

--- a/src/FluidCanvas.tsx
+++ b/src/FluidCanvas.tsx
@@ -4,10 +4,17 @@ import { MAX_STEPS_PER_FRAME, TIME_STEP } from "@/fluid/config";
 import { GpuUnavailableError, initGpu } from "@/fluid/gpu";
 import { PointerTracker } from "@/fluid/pointer";
 import { createFluidRenderer } from "@/fluid/renderer";
+import type { ResolutionSettings } from "@/fluid/resolution";
+import { DEFAULT_RESOLUTION } from "@/fluid/resolution";
 import { seedEnabled, seedSplats } from "@/fluid/seed";
 import type { FluidSettings } from "@/fluid/settings";
 import { DEFAULT_SETTINGS } from "@/fluid/settings";
-import { loadSettings, saveSettings } from "@/fluid/settingsStorage";
+import {
+  loadResolution,
+  loadSettings,
+  saveResolution,
+  saveSettings,
+} from "@/fluid/settingsStorage";
 import type { FluidRenderer, Splat } from "@/fluid/types";
 import { SettingsPanel } from "@/SettingsPanel";
 
@@ -21,12 +28,15 @@ export const FluidCanvas = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [error, setError] = useState<string | null>(null);
   const [settings, setSettings] = useState<FluidSettings>(loadSettings);
+  const [resolution, setResolution] =
+    useState<ResolutionSettings>(loadResolution);
 
   // Held in a ref as well as state: the simulation effect must not re-run —
   // and tear down the GPU device — every time a slider moves.
   const rendererRef = useRef<FluidRenderer | null>(null);
   const pointerRef = useRef<PointerTracker | null>(null);
   const settingsRef = useRef(settings);
+  const resolutionRef = useRef(resolution);
 
   const saveTimerRef = useRef<number | null>(null);
 
@@ -45,6 +55,15 @@ export const FluidCanvas = () => {
       saveTimerRef.current = null;
       saveSettings(settingsRef.current);
     }, SAVE_DEBOUNCE_MS);
+  }, []);
+
+  // Undebounced, unlike the settings above: the panel only reports a resolution
+  // once the drag ends, so there is no per-move burst to collapse.
+  const applyResolution = useCallback((next: ResolutionSettings) => {
+    resolutionRef.current = next;
+    setResolution(next);
+    rendererRef.current?.setResolution(next);
+    saveResolution(next);
   }, []);
 
   // Flushed on hide because a pending save would otherwise be lost to a tab
@@ -127,7 +146,14 @@ export const FluidCanvas = () => {
       });
 
       const { width, height } = resizeCanvas();
-      renderer = createFluidRenderer(device, context, format, width, height);
+      renderer = createFluidRenderer(
+        device,
+        context,
+        format,
+        width,
+        height,
+        resolutionRef.current,
+      );
       renderer.applySettings(settingsRef.current);
       rendererRef.current = renderer;
 
@@ -208,9 +234,12 @@ export const FluidCanvas = () => {
       <canvas ref={canvasRef} aria-label="Fluid simulation" />
       <SettingsPanel
         settings={settings}
+        resolution={resolution}
         onChange={applySettings}
+        onResolutionChange={applyResolution}
         onReset={() => {
           applySettings(DEFAULT_SETTINGS);
+          applyResolution(DEFAULT_RESOLUTION);
         }}
       />
     </>

--- a/src/SettingsPanel.test.tsx
+++ b/src/SettingsPanel.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { ResolutionSettings } from "@/fluid/resolution";
+import { DEFAULT_RESOLUTION } from "@/fluid/resolution";
 import type { FluidSettings } from "@/fluid/settings";
 import { DEFAULT_SETTINGS } from "@/fluid/settings";
 import { SettingsPanel } from "@/SettingsPanel";
@@ -10,12 +12,15 @@ afterEach(cleanup);
 
 /** Typed so assertions on the reported settings are checked, not `any`. */
 const changeSpy = () => vi.fn<(next: FluidSettings) => void>();
+const resolutionSpy = () => vi.fn<(next: ResolutionSettings) => void>();
 
 /** Narrows away the never-called case, so an assertion on the reported settings
  * fails loudly rather than on a property of `undefined`. */
-const lastReported = (spy: ReturnType<typeof changeSpy>): FluidSettings => {
+const lastReported = <Value,>(spy: {
+  mock: { lastCall: [Value] | undefined };
+}): Value => {
   const call = spy.mock.lastCall;
-  if (call === undefined) throw new Error("expected onChange to be called");
+  if (call === undefined) throw new Error("expected the handler to be called");
   return call[0];
 };
 
@@ -23,11 +28,17 @@ const renderPanel = (overrides: Partial<Parameters<typeof SettingsPanel>[0]>) =>
   render(
     <SettingsPanel
       settings={DEFAULT_SETTINGS}
+      resolution={DEFAULT_RESOLUTION}
       onChange={vi.fn()}
+      onResolutionChange={vi.fn()}
       onReset={vi.fn()}
       {...overrides}
     />,
   );
+
+const open = async (): Promise<void> => {
+  await userEvent.click(screen.getByRole("button", { name: "Open settings" }));
+};
 
 describe("SettingsPanel", () => {
   it("shows only the toggle until it is opened", async () => {
@@ -36,11 +47,9 @@ describe("SettingsPanel", () => {
     expect(screen.queryByRole("slider")).toBeNull();
     expect(screen.queryByRole("heading")).toBeNull();
 
-    await userEvent.click(
-      screen.getByRole("button", { name: "Open settings" }),
-    );
+    await open();
 
-    expect(screen.getAllByRole("slider")).toHaveLength(5);
+    expect(screen.getAllByRole("slider")).toHaveLength(7);
     expect(screen.getByRole("heading", { name: "Settings" })).toBeTruthy();
   });
 
@@ -61,9 +70,7 @@ describe("SettingsPanel", () => {
 
   it("renders each value at its descriptor's precision", async () => {
     renderPanel({});
-    await userEvent.click(
-      screen.getByRole("button", { name: "Open settings" }),
-    );
+    await open();
 
     expect(screen.getByText("0.0035")).toBeTruthy();
     expect(screen.getByText("30")).toBeTruthy();
@@ -73,9 +80,7 @@ describe("SettingsPanel", () => {
   it("reports a moved slider as a whole settings object", async () => {
     const onChange = changeSpy();
     renderPanel({ onChange });
-    await userEvent.click(
-      screen.getByRole("button", { name: "Open settings" }),
-    );
+    await open();
 
     const force = screen.getByRole("slider", { name: "Splat force" });
     fireEvent.change(force, { target: { value: "31" } });
@@ -93,9 +98,7 @@ describe("SettingsPanel", () => {
   it("clamps a value the input reports outside the descriptor's range", async () => {
     const onChange = changeSpy();
     renderPanel({ onChange });
-    await userEvent.click(
-      screen.getByRole("button", { name: "Open settings" }),
-    );
+    await open();
 
     const force = screen.getByRole("slider", { name: "Splat force" });
     force.setAttribute("max", "1000");
@@ -110,13 +113,96 @@ describe("SettingsPanel", () => {
     const onReset = vi.fn();
     const onChange = changeSpy();
     renderPanel({ onReset, onChange });
-    await userEvent.click(
-      screen.getByRole("button", { name: "Open settings" }),
-    );
+    await open();
 
     await userEvent.click(screen.getByRole("button", { name: "Reset" }));
 
     expect(onReset).toHaveBeenCalledTimes(1);
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  describe("resolution sliders", () => {
+    it("shows a dragged value without reporting it, since each report rebuilds every texture", async () => {
+      const onResolutionChange = resolutionSpy();
+      renderPanel({ onResolutionChange });
+      await open();
+
+      const sim = screen.getByRole("slider", { name: "Sim grid" });
+      fireEvent.change(sim, { target: { value: "192" } });
+      fireEvent.change(sim, { target: { value: "224" } });
+
+      expect(onResolutionChange).not.toHaveBeenCalled();
+      expect(screen.getByText("224")).toBeTruthy();
+    });
+
+    it("reports the value the drag rested on, once", async () => {
+      const onResolutionChange = resolutionSpy();
+      renderPanel({ onResolutionChange });
+      await open();
+
+      const sim = screen.getByRole("slider", { name: "Sim grid" });
+      fireEvent.change(sim, { target: { value: "192" } });
+      fireEvent.change(sim, { target: { value: "224" } });
+      fireEvent.pointerUp(sim);
+
+      expect(onResolutionChange).toHaveBeenCalledTimes(1);
+      expect(lastReported(onResolutionChange)).toEqual({
+        ...DEFAULT_RESOLUTION,
+        simResolution: 224,
+      });
+    });
+
+    it("commits a keyboard adjustment on key release", async () => {
+      const onResolutionChange = resolutionSpy();
+      renderPanel({ onResolutionChange });
+      await open();
+
+      const dye = screen.getByRole("slider", { name: "Dye grid" });
+      fireEvent.change(dye, { target: { value: "1152" } });
+      fireEvent.keyUp(dye, { key: "ArrowRight" });
+
+      expect(lastReported(onResolutionChange).dyeResolution).toBe(1152);
+    });
+
+    it("stays quiet when a release follows no movement", async () => {
+      const onResolutionChange = resolutionSpy();
+      renderPanel({ onResolutionChange });
+      await open();
+
+      fireEvent.pointerUp(screen.getByRole("slider", { name: "Sim grid" }));
+
+      expect(onResolutionChange).not.toHaveBeenCalled();
+    });
+
+    it("clamps a value the input reports outside the descriptor's range", async () => {
+      const onResolutionChange = resolutionSpy();
+      renderPanel({ onResolutionChange });
+      await open();
+
+      const sim = screen.getByRole("slider", { name: "Sim grid" });
+      sim.setAttribute("max", "8192");
+      fireEvent.change(sim, { target: { value: "8192" } });
+      fireEvent.pointerUp(sim);
+
+      expect(lastReported(onResolutionChange).simResolution).toBe(512);
+    });
+
+    it("drops an uncommitted drag when the panel is reset", async () => {
+      const onResolutionChange = resolutionSpy();
+      renderPanel({ onResolutionChange });
+      await open();
+
+      const sim = screen.getByRole("slider", { name: "Sim grid" });
+      fireEvent.change(sim, { target: { value: "192" } });
+      await userEvent.click(screen.getByRole("button", { name: "Reset" }));
+
+      // The parent's reset is the authority; a pending value surviving it would
+      // reach the renderer on the next release.
+      expect(onResolutionChange).not.toHaveBeenCalled();
+      expect(sim).toHaveProperty(
+        "value",
+        String(DEFAULT_RESOLUTION.simResolution),
+      );
+    });
   });
 });

--- a/src/SettingsPanel.test.tsx
+++ b/src/SettingsPanel.test.tsx
@@ -152,6 +152,27 @@ describe("SettingsPanel", () => {
       });
     });
 
+    it("drops a cancelled drag rather than holding it for a later release", async () => {
+      const onResolutionChange = resolutionSpy();
+      renderPanel({ onResolutionChange });
+      await open();
+
+      const sim = screen.getByRole("slider", { name: "Sim grid" });
+      fireEvent.change(sim, { target: { value: "192" } });
+      fireEvent.pointerCancel(sim);
+
+      expect(onResolutionChange).not.toHaveBeenCalled();
+      expect(sim).toHaveProperty(
+        "value",
+        String(DEFAULT_RESOLUTION.simResolution),
+      );
+
+      // A cancelled value left pending would ride out on the next release, at a
+      // moment the user never chose.
+      fireEvent.pointerUp(sim);
+      expect(onResolutionChange).not.toHaveBeenCalled();
+    });
+
     it("commits a keyboard adjustment on key release", async () => {
       const onResolutionChange = resolutionSpy();
       renderPanel({ onResolutionChange });

--- a/src/SettingsPanel.tsx
+++ b/src/SettingsPanel.tsx
@@ -11,6 +11,7 @@ interface SliderRowProps {
   value: number;
   onChange: (value: number) => void;
   onCommit?: () => void;
+  onAbandon?: () => void;
 }
 
 const SliderRow = ({
@@ -18,6 +19,7 @@ const SliderRow = ({
   value,
   onChange,
   onCommit,
+  onAbandon,
 }: SliderRowProps) => (
   <label className="settings__row">
     <span className="settings__label">{label}</span>
@@ -33,6 +35,7 @@ const SliderRow = ({
       onPointerUp={onCommit}
       onKeyUp={onCommit}
       onBlur={onCommit}
+      onPointerCancel={onAbandon}
     />
     <output className="settings__value">{value.toFixed(precision)}</output>
   </label>
@@ -65,6 +68,12 @@ export const SettingsPanel = ({
     if (pending === null) return;
     setPending(null);
     onResolutionChange(pending);
+  };
+
+  // A cancelled drag never reaches `pointerup`, so without this the value it
+  // reached would sit pending and commit at some later unrelated blur.
+  const abandonResolution = (): void => {
+    setPending(null);
   };
 
   return (
@@ -112,6 +121,7 @@ export const SettingsPanel = ({
                 });
               }}
               onCommit={commitResolution}
+              onAbandon={abandonResolution}
             />
           ))}
 
@@ -119,7 +129,7 @@ export const SettingsPanel = ({
             type="button"
             className="settings__reset"
             onClick={() => {
-              setPending(null);
+              abandonResolution();
               onReset();
             }}
           >

--- a/src/SettingsPanel.tsx
+++ b/src/SettingsPanel.tsx
@@ -1,21 +1,71 @@
 import { useId, useState } from "react";
 
+import type { SettingDescriptor } from "@/fluid/descriptor";
+import type { ResolutionSettings } from "@/fluid/resolution";
+import { clampResolution, RESOLUTION_DESCRIPTORS } from "@/fluid/resolution";
 import type { FluidSettings } from "@/fluid/settings";
 import { clampSetting, SETTING_DESCRIPTORS } from "@/fluid/settings";
 
+interface SliderRowProps {
+  descriptor: SettingDescriptor<string>;
+  value: number;
+  onChange: (value: number) => void;
+  onCommit?: () => void;
+}
+
+const SliderRow = ({
+  descriptor: { label, min, max, step, precision },
+  value,
+  onChange,
+  onCommit,
+}: SliderRowProps) => (
+  <label className="settings__row">
+    <span className="settings__label">{label}</span>
+    <input
+      type="range"
+      min={min}
+      max={max}
+      step={step}
+      value={value}
+      onChange={(event) => {
+        onChange(event.target.valueAsNumber);
+      }}
+      onPointerUp={onCommit}
+      onKeyUp={onCommit}
+      onBlur={onCommit}
+    />
+    <output className="settings__value">{value.toFixed(precision)}</output>
+  </label>
+);
+
 interface SettingsPanelProps {
   settings: FluidSettings;
+  resolution: ResolutionSettings;
   onChange: (settings: FluidSettings) => void;
+  onResolutionChange: (resolution: ResolutionSettings) => void;
   onReset: () => void;
 }
 
 export const SettingsPanel = ({
   settings,
+  resolution,
   onChange,
+  onResolutionChange,
   onReset,
 }: SettingsPanelProps) => {
   const [open, setOpen] = useState(false);
+  // Held back until the drag ends, because each committed value rebuilds every
+  // texture — far dearer than the per-move write the other sliders make.
+  const [pending, setPending] = useState<ResolutionSettings | null>(null);
   const panelId = useId();
+
+  const shownResolution = pending ?? resolution;
+
+  const commitResolution = (): void => {
+    if (pending === null) return;
+    setPending(null);
+    onResolutionChange(pending);
+  };
 
   return (
     <div className="settings">
@@ -36,34 +86,40 @@ export const SettingsPanel = ({
         <div id={panelId} className="settings__panel">
           <h2 className="settings__title">Settings</h2>
 
-          {SETTING_DESCRIPTORS.map(
-            ({ key, label, min, max, step, precision }) => (
-              <label key={key} className="settings__row">
-                <span className="settings__label">{label}</span>
-                <input
-                  type="range"
-                  min={min}
-                  max={max}
-                  step={step}
-                  value={settings[key]}
-                  onChange={(event) => {
-                    onChange({
-                      ...settings,
-                      [key]: clampSetting(key, event.target.valueAsNumber),
-                    });
-                  }}
-                />
-                <output className="settings__value">
-                  {settings[key].toFixed(precision)}
-                </output>
-              </label>
-            ),
-          )}
+          {SETTING_DESCRIPTORS.map((descriptor) => (
+            <SliderRow
+              key={descriptor.key}
+              descriptor={descriptor}
+              value={settings[descriptor.key]}
+              onChange={(value) => {
+                onChange({
+                  ...settings,
+                  [descriptor.key]: clampSetting(descriptor.key, value),
+                });
+              }}
+            />
+          ))}
+
+          {RESOLUTION_DESCRIPTORS.map((descriptor) => (
+            <SliderRow
+              key={descriptor.key}
+              descriptor={descriptor}
+              value={shownResolution[descriptor.key]}
+              onChange={(value) => {
+                setPending({
+                  ...shownResolution,
+                  [descriptor.key]: clampResolution(descriptor.key, value),
+                });
+              }}
+              onCommit={commitResolution}
+            />
+          ))}
 
           <button
             type="button"
             className="settings__reset"
             onClick={() => {
+              setPending(null);
               onReset();
             }}
           >

--- a/src/fluid/descriptor.ts
+++ b/src/fluid/descriptor.ts
@@ -1,0 +1,51 @@
+export interface SettingDescriptor<Key extends string> {
+  key: Key;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  /** Decimals shown beside the slider; the step's precision, not the value's. */
+  precision: number;
+}
+
+export interface DescriptorSet<Key extends string> {
+  clamp: (key: Key, value: number) => number;
+  normalise: (input: unknown) => Record<Key, number>;
+}
+
+export const describeSettings = <Key extends string>(
+  descriptors: readonly SettingDescriptor<Key>[],
+  defaults: Readonly<Record<Key, number>>,
+): DescriptorSet<Key> => {
+  const byKey = new Map(
+    descriptors.map((descriptor) => [descriptor.key, descriptor]),
+  );
+
+  /** A stored setting outlives the range that produced it, so a value read back
+   * is untrusted input rather than one this build wrote. */
+  const clamp = (key: Key, value: number): number => {
+    const descriptor = byKey.get(key);
+    if (descriptor === undefined || !Number.isFinite(value)) {
+      return defaults[key];
+    }
+    const bounded = Math.min(descriptor.max, Math.max(descriptor.min, value));
+    // Integer-step settings index a loop, a count or a grid edge, so a consumer
+    // given a fractional one would re-guard what the descriptor already declares.
+    return Number.isInteger(descriptor.step) ? Math.round(bounded) : bounded;
+  };
+
+  /** Falls back per key rather than wholesale, so a blob predating a key this
+   * build added still yields every slider a value. */
+  const normalise = (input: unknown): Record<Key, number> => {
+    const result: Record<Key, number> = { ...defaults };
+    if (typeof input !== "object" || input === null) return result;
+    const entries = new Map<string, unknown>(Object.entries(input));
+    for (const { key } of descriptors) {
+      const value = entries.get(key);
+      if (typeof value === "number") result[key] = clamp(key, value);
+    }
+    return result;
+  };
+
+  return { clamp, normalise };
+};

--- a/src/fluid/doubleBuffer.ts
+++ b/src/fluid/doubleBuffer.ts
@@ -1,0 +1,38 @@
+import type { Grid } from "./grid";
+
+const STORAGE_USAGE =
+  GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING;
+
+/** A pair of same-format textures written alternately: a compute pass may not
+ * read and write one texture, so each step reads `read` and writes `write`,
+ * then the two are swapped. */
+export class DoubleBuffer {
+  readonly views: readonly [GPUTextureView, GPUTextureView];
+  private readonly textures: readonly [GPUTexture, GPUTexture];
+  private liveFace: 0 | 1 = 0;
+
+  constructor(device: GPUDevice, grid: Grid, format: GPUTextureFormat) {
+    const create = (): GPUTexture =>
+      device.createTexture({
+        size: [grid.width, grid.height],
+        format,
+        usage: STORAGE_USAGE,
+      });
+    const first = create();
+    const second = create();
+    this.textures = [first, second];
+    this.views = [first.createView(), second.createView()];
+  }
+
+  get readFace(): 0 | 1 {
+    return this.liveFace;
+  }
+
+  swap(): void {
+    this.liveFace = this.liveFace === 0 ? 1 : 0;
+  }
+
+  destroy(): void {
+    for (const texture of this.textures) texture.destroy();
+  }
+}

--- a/src/fluid/grid.test.ts
+++ b/src/fluid/grid.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { WORKGROUP_SIZE } from "./config";
+import { dispatchSize, fitGrid } from "./grid";
+import { RESOLUTION_DESCRIPTORS } from "./resolution";
+
+/** The extremes of a viewport, so a resolution the panel offers is checked
+ * against the shapes it actually has to fit. */
+const VIEWPORTS = [
+  { width: 1920, height: 1080 },
+  { width: 1080, height: 1920 },
+  { width: 1000, height: 1000 },
+  { width: 3840, height: 800 },
+  { width: 320, height: 1400 },
+] as const;
+
+const resolutionStops = (key: "simResolution" | "dyeResolution"): number[] => {
+  const descriptor = RESOLUTION_DESCRIPTORS.find((it) => it.key === key);
+  if (descriptor === undefined) throw new Error(`no descriptor for ${key}`);
+  const stops: number[] = [];
+  for (let v = descriptor.min; v <= descriptor.max; v += descriptor.step) {
+    stops.push(v);
+  }
+  return stops;
+};
+
+describe("fitGrid", () => {
+  it("puts the resolution on the longer axis and derives the shorter one", () => {
+    expect(fitGrid(1920, 1080, 320)).toEqual({ width: 320, height: 180 });
+    expect(fitGrid(1080, 1920, 320)).toEqual({ width: 180, height: 320 });
+    expect(fitGrid(1000, 1000, 320)).toEqual({ width: 320, height: 320 });
+  });
+
+  it("keeps cells square, which is what stops the fluid stretching", () => {
+    const { width, height } = fitGrid(1600, 900, 256);
+    expect(width / height).toBeCloseTo(1600 / 900, 1);
+  });
+
+  it("never falls below the 2 cells the difference stencils need", () => {
+    // An extreme aspect drives the short axis toward zero; a 1-cell or 0-cell
+    // grid would make every neighbour read a clamped copy of the centre.
+    expect(fitGrid(4000, 10, 64).height).toBeGreaterThanOrEqual(2);
+    expect(fitGrid(10, 4000, 64).width).toBeGreaterThanOrEqual(2);
+  });
+
+  it("returns whole cells for every resolution the panel can produce", () => {
+    for (const key of ["simResolution", "dyeResolution"] as const) {
+      for (const resolution of resolutionStops(key)) {
+        for (const { width, height } of VIEWPORTS) {
+          const grid = fitGrid(width, height, resolution);
+          expect(Number.isInteger(grid.width)).toBe(true);
+          expect(Number.isInteger(grid.height)).toBe(true);
+          expect(grid.width).toBeGreaterThanOrEqual(2);
+          expect(grid.height).toBeGreaterThanOrEqual(2);
+        }
+      }
+    }
+  });
+});
+
+describe("dispatchSize", () => {
+  it("rounds up, so the trailing partial workgroup still covers its cells", () => {
+    expect(
+      dispatchSize({ width: WORKGROUP_SIZE, height: WORKGROUP_SIZE }),
+    ).toEqual([1, 1]);
+    expect(
+      dispatchSize({ width: WORKGROUP_SIZE + 1, height: WORKGROUP_SIZE * 2 }),
+    ).toEqual([2, 2]);
+  });
+
+  it("covers every cell of every grid the panel can ask for", () => {
+    for (const key of ["simResolution", "dyeResolution"] as const) {
+      for (const resolution of resolutionStops(key)) {
+        for (const { width, height } of VIEWPORTS) {
+          const grid = fitGrid(width, height, resolution);
+          const [x, y] = dispatchSize(grid);
+          expect(x * WORKGROUP_SIZE).toBeGreaterThanOrEqual(grid.width);
+          expect(y * WORKGROUP_SIZE).toBeGreaterThanOrEqual(grid.height);
+        }
+      }
+    }
+  });
+});

--- a/src/fluid/grid.ts
+++ b/src/fluid/grid.ts
@@ -1,0 +1,29 @@
+import { WORKGROUP_SIZE } from "./config";
+
+export interface Grid {
+  width: number;
+  height: number;
+}
+
+/** Fit a grid of `resolution` cells on its longer axis to the canvas' aspect,
+ * so cells stay square and the fluid is not stretched. */
+export const fitGrid = (
+  width: number,
+  height: number,
+  resolution: number,
+): Grid => {
+  const aspect = width / height;
+  const cells =
+    aspect >= 1
+      ? { width: resolution, height: resolution / aspect }
+      : { width: resolution * aspect, height: resolution };
+  return {
+    width: Math.max(2, Math.round(cells.width)),
+    height: Math.max(2, Math.round(cells.height)),
+  };
+};
+
+export const dispatchSize = (grid: Grid): [number, number] => [
+  Math.ceil(grid.width / WORKGROUP_SIZE),
+  Math.ceil(grid.height / WORKGROUP_SIZE),
+];

--- a/src/fluid/renderer.ts
+++ b/src/fluid/renderer.ts
@@ -1,13 +1,11 @@
-import {
-  DYE_RESOLUTION,
-  MAX_SPLATS_PER_FRAME,
-  SIM_RESOLUTION,
-  TIME_STEP,
-  WORKGROUP_SIZE,
-} from "./config";
+import { MAX_SPLATS_PER_FRAME, TIME_STEP, WORKGROUP_SIZE } from "./config";
 import type { ProjectionScale } from "./projection";
 import { projectionScale, projectionUniform } from "./projection";
 import renderShaderSource from "./render.wgsl?raw";
+import type { ResampleField } from "./resample";
+import { createFieldResampler } from "./resample";
+import type { ResolutionSettings } from "./resolution";
+import { DEFAULT_RESOLUTION } from "./resolution";
 import type { FluidSettings } from "./settings";
 import { DEFAULT_SETTINGS } from "./settings";
 import simulationShaderSource from "./simulation.wgsl?raw";
@@ -118,6 +116,7 @@ export const createFluidRenderer = (
   canvasFormat: GPUTextureFormat,
   width: number,
   height: number,
+  initialResolution: ResolutionSettings = DEFAULT_RESOLUTION,
 ): FluidRenderer => {
   // Substituted rather than duplicated: the host's dispatch count and the
   // shader's workgroup size must agree, and a drift under-simulates in silence.
@@ -317,15 +316,31 @@ export const createFluidRenderer = (
     display: FacePair;
   }
 
+  const resampler = createFieldResampler(
+    device,
+    simulationModule,
+    sharedLayout,
+  );
+
   let resources: Resources | null = null;
   let settings: FluidSettings = DEFAULT_SETTINGS;
+  let resolution: ResolutionSettings = initialResolution;
+  let canvas = { width, height };
 
   const buildResources = (
     canvasWidth: number,
     canvasHeight: number,
   ): Resources => {
-    const simGrid = fitGrid(canvasWidth, canvasHeight, SIM_RESOLUTION);
-    const dyeGrid = fitGrid(canvasWidth, canvasHeight, DYE_RESOLUTION);
+    const simGrid = fitGrid(
+      canvasWidth,
+      canvasHeight,
+      resolution.simResolution,
+    );
+    const dyeGrid = fitGrid(
+      canvasWidth,
+      canvasHeight,
+      resolution.dyeResolution,
+    );
     const scale = projectionScale(simGrid.width, simGrid.height);
 
     const velocity = new DoubleBuffer(device, simGrid, VELOCITY_FORMAT);
@@ -486,9 +501,58 @@ export const createFluidRenderer = (
     for (const buffer of current.ownedParamBuffers) buffer.destroy();
   };
 
+  const liveFace = (buffer: DoubleBuffer, grid: Grid): ResampleField => ({
+    view: buffer.views[buffer.readFace],
+    width: grid.width,
+    height: grid.height,
+  });
+
+  /** Pressure is left behind rather than carried: the Jacobi sweeps rebuild it
+   * from the divergence within the frame, so resampling it buys nothing. */
+  const carryFields = (previous: Resources, next: Resources): void => {
+    const encoder = device.createCommandEncoder({ label: "fluid-rebuild" });
+    const pass = encoder.beginComputePass();
+    pass.setBindGroup(0, sharedBindGroup);
+    resampler.encodeInto(pass, [
+      {
+        source: liveFace(previous.velocity, previous.simGrid),
+        target: liveFace(next.velocity, next.simGrid),
+      },
+      {
+        source: liveFace(previous.dye, previous.dyeGrid),
+        target: liveFace(next.dye, next.dyeGrid),
+      },
+    ]);
+    pass.end();
+    device.queue.submit([encoder.finish()]);
+  };
+
+  /** Builds before releasing so the old fields can be resampled onto the new
+   * grids; the two sets overlap for one submit, doubling texture memory. */
+  const rebuild = (canvasWidth: number, canvasHeight: number): void => {
+    const previous = resources;
+    const next = buildResources(canvasWidth, canvasHeight);
+    if (previous !== null) {
+      carryFields(previous, next);
+      releaseResources(previous);
+    }
+    resources = next;
+  };
+
   const resize = (canvasWidth: number, canvasHeight: number): void => {
-    if (resources !== null) releaseResources(resources);
-    resources = buildResources(canvasWidth, canvasHeight);
+    canvas = { width: canvasWidth, height: canvasHeight };
+    rebuild(canvasWidth, canvasHeight);
+  };
+
+  const setResolution = (next: ResolutionSettings): void => {
+    if (
+      next.simResolution === resolution.simResolution &&
+      next.dyeResolution === resolution.dyeResolution
+    ) {
+      return;
+    }
+    resolution = next;
+    rebuild(canvas.width, canvas.height);
   };
 
   const writeDissipation = (buffer: GPUBuffer, rate: number): void => {
@@ -633,10 +697,12 @@ export const createFluidRenderer = (
   return {
     frame,
     applySettings,
+    setResolution,
     resize,
     destroy: () => {
       if (resources !== null) releaseResources(resources);
       resources = null;
+      resampler.destroy();
       uniformBuffer.destroy();
       splatBuffer.destroy();
     },

--- a/src/fluid/renderer.ts
+++ b/src/fluid/renderer.ts
@@ -1,11 +1,13 @@
 import { MAX_SPLATS_PER_FRAME, TIME_STEP, WORKGROUP_SIZE } from "./config";
+import { DoubleBuffer } from "./doubleBuffer";
+import type { Grid } from "./grid";
+import { dispatchSize, fitGrid } from "./grid";
 import type { ProjectionScale } from "./projection";
 import { projectionScale, projectionUniform } from "./projection";
 import renderShaderSource from "./render.wgsl?raw";
 import type { ResampleField } from "./resample";
 import { createFieldResampler } from "./resample";
 import type { ResolutionSettings } from "./resolution";
-import { DEFAULT_RESOLUTION } from "./resolution";
 import type { FluidSettings } from "./settings";
 import { DEFAULT_SETTINGS } from "./settings";
 import simulationShaderSource from "./simulation.wgsl?raw";
@@ -51,72 +53,13 @@ const PRESSURE_FORMAT: GPUTextureFormat = "r32float";
 const STORAGE_USAGE =
   GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING;
 
-interface Grid {
-  width: number;
-  height: number;
-}
-
-/** A pair of same-format textures written alternately: a compute pass may not
- * read and write one texture, so each step reads `read` and writes `write`,
- * then the two are swapped. */
-class DoubleBuffer {
-  readonly views: readonly [GPUTextureView, GPUTextureView];
-  private readonly textures: readonly [GPUTexture, GPUTexture];
-  /** Which of the two faces currently holds the live field. */
-  private face: 0 | 1 = 0;
-
-  constructor(device: GPUDevice, grid: Grid, format: GPUTextureFormat) {
-    const create = (): GPUTexture =>
-      device.createTexture({
-        size: [grid.width, grid.height],
-        format,
-        usage: STORAGE_USAGE,
-      });
-    const first = create();
-    const second = create();
-    this.textures = [first, second];
-    this.views = [first.createView(), second.createView()];
-  }
-
-  get readFace(): 0 | 1 {
-    return this.face;
-  }
-
-  swap(): void {
-    this.face = this.face === 0 ? 1 : 0;
-  }
-
-  destroy(): void {
-    for (const texture of this.textures) texture.destroy();
-  }
-}
-
-/** Fit a grid of `resolution` cells on its longer axis to the canvas' aspect,
- * so cells stay square and the fluid is not stretched. */
-const fitGrid = (width: number, height: number, resolution: number): Grid => {
-  const aspect = width / height;
-  const cells =
-    aspect >= 1
-      ? { width: resolution, height: resolution / aspect }
-      : { width: resolution * aspect, height: resolution };
-  return {
-    width: Math.max(2, Math.round(cells.width)),
-    height: Math.max(2, Math.round(cells.height)),
-  };
-};
-
-const dispatchSize = (grid: Grid): [number, number] => [
-  Math.ceil(grid.width / WORKGROUP_SIZE),
-  Math.ceil(grid.height / WORKGROUP_SIZE),
-];
-
 export const createFluidRenderer = (
   device: GPUDevice,
   context: GPUCanvasContext,
   canvasFormat: GPUTextureFormat,
   width: number,
   height: number,
-  initialResolution: ResolutionSettings = DEFAULT_RESOLUTION,
+  initialResolution: ResolutionSettings,
 ): FluidRenderer => {
   // Substituted rather than duplicated: the host's dispatch count and the
   // shader's workgroup size must agree, and a drift under-simulates in silence.
@@ -325,7 +268,7 @@ export const createFluidRenderer = (
   let resources: Resources | null = null;
   let settings: FluidSettings = DEFAULT_SETTINGS;
   let resolution: ResolutionSettings = initialResolution;
-  let canvas = { width, height };
+  let canvasSize = { width, height };
 
   const buildResources = (
     canvasWidth: number,
@@ -540,7 +483,7 @@ export const createFluidRenderer = (
   };
 
   const resize = (canvasWidth: number, canvasHeight: number): void => {
-    canvas = { width: canvasWidth, height: canvasHeight };
+    canvasSize = { width: canvasWidth, height: canvasHeight };
     rebuild(canvasWidth, canvasHeight);
   };
 
@@ -552,7 +495,7 @@ export const createFluidRenderer = (
       return;
     }
     resolution = next;
-    rebuild(canvas.width, canvas.height);
+    rebuild(canvasSize.width, canvasSize.height);
   };
 
   const writeDissipation = (buffer: GPUBuffer, rate: number): void => {

--- a/src/fluid/resample.test.ts
+++ b/src/fluid/resample.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * The `resample` pass rebuilt on the CPU, from the same expressions
+ * `simulation.wgsl` uses. A rebuild is the only thing that runs it, and a
+ * rebuild that carried the field wrongly still looks like a fluid — a half-cell
+ * slip or an inverted axis is invisible to the Playwright suite and breaks an
+ * assertion below.
+ *
+ * Transcribed by hand, so this checks the mapping, not the shader: editing
+ * `resample` or `sampleAt` means editing its twin here.
+ */
+
+interface Field {
+  readonly width: number;
+  readonly height: number;
+  readonly data: Float64Array;
+}
+
+const fieldFrom = (
+  width: number,
+  height: number,
+  value: (x: number, y: number) => number,
+): Field => {
+  const data = new Float64Array(width * height);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) data[y * width + x] = value(x, y);
+  }
+  return { width, height, data };
+};
+
+const loadAt = (f: Field, x: number, y: number): number => {
+  const cx = Math.min(Math.max(x, 0), f.width - 1);
+  const cy = Math.min(Math.max(y, 0), f.height - 1);
+  return f.data[cy * f.width + cx] ?? 0;
+};
+
+const sampleAt = (f: Field, x: number, y: number): number => {
+  const baseX = Math.floor(x);
+  const baseY = Math.floor(y);
+  const fx = x - baseX;
+  const fy = y - baseY;
+
+  const c00 = loadAt(f, baseX, baseY);
+  const c10 = loadAt(f, baseX + 1, baseY);
+  const c01 = loadAt(f, baseX, baseY + 1);
+  const c11 = loadAt(f, baseX + 1, baseY + 1);
+
+  return (c00 + (c10 - c00) * fx) * (1 - fy) + (c01 + (c11 - c01) * fx) * fy;
+};
+
+const resample = (source: Field, width: number, height: number): Field =>
+  fieldFrom(width, height, (x, y) =>
+    sampleAt(
+      source,
+      ((x + 0.5) / width) * source.width - 0.5,
+      ((y + 0.5) / height) * source.height - 0.5,
+    ),
+  );
+
+describe("resample", () => {
+  it("is the identity when the grids match", () => {
+    const source = fieldFrom(7, 5, (x, y) => x * 10 + y);
+    expect([...resample(source, 7, 5).data]).toEqual([...source.data]);
+  });
+
+  it("carries a constant field through both directions unchanged", () => {
+    const source = fieldFrom(8, 6, () => 3.5);
+
+    for (const value of resample(source, 20, 15).data) {
+      expect(value).toBeCloseTo(3.5, 12);
+    }
+    for (const value of resample(source, 3, 2).data) {
+      expect(value).toBeCloseTo(3.5, 12);
+    }
+  });
+
+  it("keeps a linear ramp linear across an upscale, so the field does not shift", () => {
+    const ramp = (cells: number, index: number): number =>
+      (index + 0.5) / cells;
+    const source = fieldFrom(8, 8, (x) => ramp(8, x));
+    const carried = resample(source, 24, 8);
+
+    for (let x = 0; x < 24; x++) {
+      const expected = ramp(24, x);
+      // The edge half-cells clamp rather than extrapolate, so only the interior
+      // can reproduce the ramp exactly.
+      if (expected < ramp(8, 0) || expected > ramp(8, 7)) continue;
+      expect(carried.data[x]).toBeCloseTo(expected, 12);
+    }
+  });
+
+  it("preserves which side a feature sits on, so neither axis flips", () => {
+    const source = fieldFrom(8, 8, (x, y) => (x < 4 && y < 4 ? 1 : 0));
+    const carried = resample(source, 16, 16);
+
+    const at = (x: number, y: number): number => carried.data[y * 16 + x] ?? -1;
+    expect(at(1, 1)).toBeCloseTo(1, 12);
+    expect(at(14, 1)).toBeCloseTo(0, 12);
+    expect(at(1, 14)).toBeCloseTo(0, 12);
+  });
+});

--- a/src/fluid/resample.ts
+++ b/src/fluid/resample.ts
@@ -1,0 +1,116 @@
+import { WORKGROUP_SIZE } from "./config";
+
+const PARAM_BYTES = 16;
+
+export interface ResampleField {
+  view: GPUTextureView;
+  width: number;
+  height: number;
+}
+
+export interface ResamplePair {
+  source: ResampleField;
+  target: ResampleField;
+}
+
+export interface FieldResampler {
+  encodeInto: (
+    pass: GPUComputePassEncoder,
+    pairs: readonly ResamplePair[],
+  ) => void;
+  destroy: () => void;
+}
+
+/** Carries a field onto a differently-sized grid, so a rebuild can preserve
+ * what the solver had rather than starting from an empty texture. */
+export const createFieldResampler = (
+  device: GPUDevice,
+  module: GPUShaderModule,
+  sharedLayout: GPUBindGroupLayout,
+): FieldResampler => {
+  const layout = device.createBindGroupLayout({
+    entries: [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.COMPUTE,
+        texture: { sampleType: "unfilterable-float" },
+      },
+      {
+        binding: 1,
+        visibility: GPUShaderStage.COMPUTE,
+        storageTexture: { access: "write-only", format: "rgba32float" },
+      },
+      {
+        binding: 2,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: "uniform" },
+      },
+    ],
+  });
+
+  const pipeline = device.createComputePipeline({
+    label: "resample",
+    layout: device.createPipelineLayout({
+      bindGroupLayouts: [sharedLayout, layout],
+    }),
+    compute: { module, entryPoint: "resample" },
+  });
+
+  // One buffer per pair, not one reused: a rebuild encodes every dispatch
+  // before its submit, so a shared buffer would hand them all the last sizes.
+  const paramBuffers: GPUBuffer[] = [];
+  const paramsFor = (index: number): GPUBuffer => {
+    const existing = paramBuffers[index];
+    if (existing !== undefined) return existing;
+    const created = device.createBuffer({
+      label: `resample-params-${String(index)}`,
+      size: PARAM_BYTES,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    paramBuffers[index] = created;
+    return created;
+  };
+
+  const encodeInto = (
+    pass: GPUComputePassEncoder,
+    pairs: readonly ResamplePair[],
+  ): void => {
+    pass.setPipeline(pipeline);
+    pairs.forEach(({ source, target }, index) => {
+      const params = paramsFor(index);
+      device.queue.writeBuffer(
+        params,
+        0,
+        new Float32Array([
+          source.width,
+          source.height,
+          target.width,
+          target.height,
+        ]),
+      );
+      pass.setBindGroup(
+        1,
+        device.createBindGroup({
+          layout,
+          entries: [
+            { binding: 0, resource: source.view },
+            { binding: 1, resource: target.view },
+            { binding: 2, resource: { buffer: params } },
+          ],
+        }),
+      );
+      pass.dispatchWorkgroups(
+        Math.ceil(target.width / WORKGROUP_SIZE),
+        Math.ceil(target.height / WORKGROUP_SIZE),
+      );
+    });
+  };
+
+  return {
+    encodeInto,
+    destroy: () => {
+      for (const buffer of paramBuffers) buffer.destroy();
+      paramBuffers.length = 0;
+    },
+  };
+};

--- a/src/fluid/resolution.test.ts
+++ b/src/fluid/resolution.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clampResolution,
+  DEFAULT_RESOLUTION,
+  normaliseResolution,
+  RESOLUTION_DESCRIPTORS,
+} from "./resolution";
+
+describe("RESOLUTION_DESCRIPTORS", () => {
+  it("brackets every default, so the panel opens on a reachable value", () => {
+    for (const { key, min, max } of RESOLUTION_DESCRIPTORS) {
+      expect(DEFAULT_RESOLUTION[key]).toBeGreaterThanOrEqual(min);
+      expect(DEFAULT_RESOLUTION[key]).toBeLessThanOrEqual(max);
+    }
+  });
+
+  it("places every default on a step, so the slider can return to it", () => {
+    for (const { key, min, step } of RESOLUTION_DESCRIPTORS) {
+      expect((DEFAULT_RESOLUTION[key] - min) % step).toBe(0);
+    }
+  });
+});
+
+describe("clampResolution", () => {
+  it("holds a value inside the descriptor's range", () => {
+    expect(clampResolution("simResolution", 8192)).toBe(512);
+    expect(clampResolution("dyeResolution", 1)).toBe(256);
+  });
+
+  it("rounds to a whole cell count, which fitGrid and the dispatch both index", () => {
+    expect(clampResolution("simResolution", 200.6)).toBe(201);
+  });
+
+  it("falls back to the default rather than passing NaN to a grid size", () => {
+    expect(clampResolution("simResolution", Number.NaN)).toBe(
+      DEFAULT_RESOLUTION.simResolution,
+    );
+  });
+});
+
+describe("normaliseResolution", () => {
+  it("returns the defaults for a blob that predates the resolution channel", () => {
+    expect(normaliseResolution(null)).toEqual(DEFAULT_RESOLUTION);
+    expect(normaliseResolution({})).toEqual(DEFAULT_RESOLUTION);
+  });
+
+  it("keeps the defaults for keys the stored blob omits", () => {
+    expect(normaliseResolution({ simResolution: 128 })).toEqual({
+      simResolution: 128,
+      dyeResolution: DEFAULT_RESOLUTION.dyeResolution,
+    });
+  });
+
+  it("clamps a stored value the current build no longer offers", () => {
+    expect(normaliseResolution({ dyeResolution: 99999 }).dyeResolution).toBe(
+      2048,
+    );
+  });
+
+  it("never returns the defaults object itself, so a caller cannot mutate it", () => {
+    expect(normaliseResolution({})).not.toBe(DEFAULT_RESOLUTION);
+  });
+});

--- a/src/fluid/resolution.ts
+++ b/src/fluid/resolution.ts
@@ -1,0 +1,45 @@
+import { DYE_RESOLUTION, SIM_RESOLUTION } from "./config";
+import type { SettingDescriptor } from "./descriptor";
+import { describeSettings } from "./descriptor";
+
+/** Held apart from `FluidSettings` because these cannot take effect on the next
+ * frame: changing one rebuilds every texture. */
+export interface ResolutionSettings {
+  simResolution: number;
+  dyeResolution: number;
+}
+
+export const DEFAULT_RESOLUTION: ResolutionSettings = {
+  simResolution: SIM_RESOLUTION,
+  dyeResolution: DYE_RESOLUTION,
+};
+
+/** Two sliders rather than one quality dial: the grids are sized for different
+ * reasons, so a fixed ratio would hide the trade the panel exists to offer. */
+export const RESOLUTION_DESCRIPTORS: readonly SettingDescriptor<
+  keyof ResolutionSettings
+>[] = [
+  {
+    key: "simResolution",
+    label: "Sim grid",
+    min: 64,
+    max: 512,
+    step: 32,
+    precision: 0,
+  },
+  {
+    key: "dyeResolution",
+    label: "Dye grid",
+    min: 256,
+    max: 2048,
+    step: 128,
+    precision: 0,
+  },
+];
+
+const resolution = describeSettings(RESOLUTION_DESCRIPTORS, DEFAULT_RESOLUTION);
+
+export const clampResolution = resolution.clamp;
+
+export const normaliseResolution = (input: unknown): ResolutionSettings =>
+  resolution.normalise(input);

--- a/src/fluid/settings.ts
+++ b/src/fluid/settings.ts
@@ -5,6 +5,8 @@ import {
   SPLAT_RADIUS,
   VELOCITY_DISSIPATION,
 } from "./config";
+import type { SettingDescriptor } from "./descriptor";
+import { describeSettings } from "./descriptor";
 
 /** Only constants that take effect on the next frame: anything that resizes a
  * grid or rebuilds a pipeline would make the panel a restart, not a control. */
@@ -24,17 +26,9 @@ export const DEFAULT_SETTINGS: FluidSettings = {
   pressureIterations: PRESSURE_ITERATIONS,
 };
 
-export interface SettingDescriptor {
-  key: keyof FluidSettings;
-  label: string;
-  min: number;
-  max: number;
-  step: number;
-  /** Decimals shown beside the slider; the step's precision, not the value's. */
-  precision: number;
-}
-
-export const SETTING_DESCRIPTORS: readonly SettingDescriptor[] = [
+export const SETTING_DESCRIPTORS: readonly SettingDescriptor<
+  keyof FluidSettings
+>[] = [
   {
     key: "velocityDissipation",
     label: "Velocity decay",
@@ -77,35 +71,9 @@ export const SETTING_DESCRIPTORS: readonly SettingDescriptor[] = [
   },
 ];
 
-const DESCRIPTORS_BY_KEY = new Map(
-  SETTING_DESCRIPTORS.map((descriptor) => [descriptor.key, descriptor]),
-);
+const settings = describeSettings(SETTING_DESCRIPTORS, DEFAULT_SETTINGS);
 
-/** A stored setting outlives the range that produced it, so a value read back
- * is untrusted input rather than one this build wrote. */
-export const clampSetting = (
-  key: keyof FluidSettings,
-  value: number,
-): number => {
-  const descriptor = DESCRIPTORS_BY_KEY.get(key);
-  if (descriptor === undefined || !Number.isFinite(value)) {
-    return DEFAULT_SETTINGS[key];
-  }
-  const bounded = Math.min(descriptor.max, Math.max(descriptor.min, value));
-  // Integer-step settings index a loop or a count, so a consumer receiving a
-  // fractional one would have to re-guard what the descriptor already declares.
-  return Number.isInteger(descriptor.step) ? Math.round(bounded) : bounded;
-};
+export const clampSetting = settings.clamp;
 
-/** Falls back per key rather than wholesale, so a blob predating a key this
- * build added still yields every slider a value. */
-export const normaliseSettings = (input: unknown): FluidSettings => {
-  if (typeof input !== "object" || input === null) return DEFAULT_SETTINGS;
-  const entries = new Map<string, unknown>(Object.entries(input));
-  const result = { ...DEFAULT_SETTINGS };
-  for (const { key } of SETTING_DESCRIPTORS) {
-    const value = entries.get(key);
-    if (typeof value === "number") result[key] = clampSetting(key, value);
-  }
-  return result;
-};
+export const normaliseSettings = (input: unknown): FluidSettings =>
+  settings.normalise(input);

--- a/src/fluid/settings.ts
+++ b/src/fluid/settings.ts
@@ -8,8 +8,8 @@ import {
 import type { SettingDescriptor } from "./descriptor";
 import { describeSettings } from "./descriptor";
 
-/** Only constants that take effect on the next frame: anything that resizes a
- * grid or rebuilds a pipeline would make the panel a restart, not a control. */
+/** Only constants that take effect on the next frame. Grid sizes cannot, so
+ * they travel on their own channel — see `ResolutionSettings`. */
 export interface FluidSettings {
   velocityDissipation: number;
   dyeDissipation: number;

--- a/src/fluid/settingsStorage.test.ts
+++ b/src/fluid/settingsStorage.test.ts
@@ -1,12 +1,33 @@
+import type { MockInstance } from "vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { DEFAULT_RESOLUTION } from "./resolution";
 import { DEFAULT_SETTINGS } from "./settings";
-import { loadSettings, saveSettings } from "./settingsStorage";
+import {
+  loadResolution,
+  loadSettings,
+  saveResolution,
+  saveSettings,
+} from "./settingsStorage";
 
 const STORAGE_KEY = "dreamvision.settings";
+const RESOLUTION_KEY = "dreamvision.resolution";
+
+// Restored by hand: `vi.restoreAllMocks` does not reach a spy installed on
+// happy-dom's `localStorage` proxy, so one left behind breaks the next test.
+const installed: MockInstance[] = [];
+
+const breakStorage = (method: "getItem" | "setItem", reason: string): void => {
+  installed.push(
+    vi.spyOn(window.localStorage, method).mockImplementation(() => {
+      throw new Error(reason);
+    }),
+  );
+};
 
 afterEach(() => {
-  vi.restoreAllMocks();
+  for (const spy of installed) spy.mockRestore();
+  installed.length = 0;
   window.localStorage.clear();
 });
 
@@ -35,20 +56,63 @@ describe("loadSettings", () => {
   });
 
   it("survives a getItem that throws, as a private window's does", () => {
-    vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
-      throw new Error("SecurityError");
-    });
+    breakStorage("getItem", "SecurityError");
     expect(loadSettings()).toEqual(DEFAULT_SETTINGS);
   });
 });
 
 describe("saveSettings", () => {
   it("survives a setItem that throws, leaving the session usable", () => {
-    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
-      throw new Error("QuotaExceededError");
-    });
+    breakStorage("setItem", "QuotaExceededError");
     expect(() => {
       saveSettings(DEFAULT_SETTINGS);
+    }).not.toThrow();
+  });
+});
+
+describe("loadResolution", () => {
+  it("returns the defaults when nothing is stored", () => {
+    expect(loadResolution()).toEqual(DEFAULT_RESOLUTION);
+  });
+
+  it("reads back what saveResolution wrote", () => {
+    const stored = { ...DEFAULT_RESOLUTION, simResolution: 128 };
+    saveResolution(stored);
+    expect(loadResolution()).toEqual(stored);
+  });
+
+  it("falls back to the defaults on a corrupt blob", () => {
+    window.localStorage.setItem(RESOLUTION_KEY, "{not json");
+    expect(loadResolution()).toEqual(DEFAULT_RESOLUTION);
+  });
+
+  it("normalises an out-of-range stored value rather than trusting it", () => {
+    window.localStorage.setItem(
+      RESOLUTION_KEY,
+      JSON.stringify({ dyeResolution: 1e6 }),
+    );
+    expect(loadResolution().dyeResolution).toBe(2048);
+  });
+
+  it("survives a getItem that throws, as a private window's does", () => {
+    breakStorage("getItem", "SecurityError");
+    expect(loadResolution()).toEqual(DEFAULT_RESOLUTION);
+  });
+});
+
+describe("saveResolution", () => {
+  it("leaves the settings blob alone, so the two channels cannot clobber", () => {
+    saveSettings(DEFAULT_SETTINGS);
+    saveResolution({ ...DEFAULT_RESOLUTION, simResolution: 128 });
+
+    expect(loadSettings()).toEqual(DEFAULT_SETTINGS);
+    expect(loadResolution().simResolution).toBe(128);
+  });
+
+  it("survives a setItem that throws, leaving the session usable", () => {
+    breakStorage("setItem", "QuotaExceededError");
+    expect(() => {
+      saveResolution(DEFAULT_RESOLUTION);
     }).not.toThrow();
   });
 });

--- a/src/fluid/settingsStorage.ts
+++ b/src/fluid/settingsStorage.ts
@@ -1,26 +1,44 @@
+import type { ResolutionSettings } from "./resolution";
+import { normaliseResolution } from "./resolution";
 import type { FluidSettings } from "./settings";
-import { DEFAULT_SETTINGS, normaliseSettings } from "./settings";
+import { normaliseSettings } from "./settings";
 
-const STORAGE_KEY = "dreamvision.settings";
+const SETTINGS_KEY = "dreamvision.settings";
+const RESOLUTION_KEY = "dreamvision.resolution";
 
 /** Guarded because `localStorage` throws on the access itself in a private
  * window or with site data blocked, not merely returning null. */
-export const loadSettings = (): FluidSettings => {
+const read = (key: string): unknown => {
   try {
-    const stored = window.localStorage.getItem(STORAGE_KEY);
-    if (stored === null) return DEFAULT_SETTINGS;
-    return normaliseSettings(JSON.parse(stored));
+    const stored = window.localStorage.getItem(key);
+    return stored === null ? null : JSON.parse(stored);
   } catch {
-    return DEFAULT_SETTINGS;
+    return null;
   }
 };
 
 /** Swallowed because a full or blocked store costs the user persistence, not
  * the session — the settings they just moved still drive this frame. */
-export const saveSettings = (settings: FluidSettings): void => {
+const write = (key: string, value: unknown): void => {
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    window.localStorage.setItem(key, JSON.stringify(value));
   } catch {
     return;
   }
+};
+
+export const loadSettings = (): FluidSettings =>
+  normaliseSettings(read(SETTINGS_KEY));
+
+export const saveSettings = (settings: FluidSettings): void => {
+  write(SETTINGS_KEY, settings);
+};
+
+// Its own key, not a field on the settings blob, so a blob written before this
+// build still loads without its missing resolution keys reading as a change.
+export const loadResolution = (): ResolutionSettings =>
+  normaliseResolution(read(RESOLUTION_KEY));
+
+export const saveResolution = (resolution: ResolutionSettings): void => {
+  write(RESOLUTION_KEY, resolution);
 };

--- a/src/fluid/simulation.wgsl
+++ b/src/fluid/simulation.wgsl
@@ -169,6 +169,31 @@ fn gradientSubtract(@builtin(global_invocation_id) gid: vec3u) {
   textureStore(gradientOutput, gid.xy, vec4f(bounded, 0.0, 1.0));
 }
 
+// ------------------------------------------------------------------ resample
+
+struct ResampleParams {
+  sourceSize: vec2f,
+  targetSize: vec2f,
+}
+
+@group(1) @binding(0) var resampleSource: texture_2d<f32>;
+@group(1) @binding(1) var resampleOutput: texture_storage_2d<rgba32float, write>;
+@group(1) @binding(2) var<uniform> resampleParams: ResampleParams;
+
+/// Carry a field onto a grid of a different size. Both grids cover the same
+/// region, so the target cell's centre maps onto the source's cell space and
+/// `sampleAt` gathers what was there.
+@compute @workgroup_size(WORKGROUP_SIZE, WORKGROUP_SIZE)
+fn resample(@builtin(global_invocation_id) gid: vec3u) {
+  let size = vec2u(resampleParams.targetSize);
+  if (gid.x >= size.x || gid.y >= size.y) { return; }
+
+  let cell = (vec2f(gid.xy) + 0.5) / resampleParams.targetSize
+    * resampleParams.sourceSize - 0.5;
+  let carried = sampleAt(resampleSource, resampleParams.sourceSize, cell);
+  textureStore(resampleOutput, gid.xy, carried);
+}
+
 // --------------------------------------------------------------------- splat
 
 struct SplatParams {

--- a/src/fluid/types.ts
+++ b/src/fluid/types.ts
@@ -1,3 +1,4 @@
+import type { ResolutionSettings } from "./resolution";
 import type { FluidSettings } from "./settings";
 
 /** One blob of force and colour injected into the fields. */
@@ -15,6 +16,7 @@ export interface FluidRenderer {
   /** Advance and draw one frame, injecting each splat before the projection. */
   frame: (splats: readonly Splat[]) => void;
   applySettings: (settings: FluidSettings) => void;
+  setResolution: (resolution: ResolutionSettings) => void;
   resize: (width: number, height: number) => void;
   destroy: () => void;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
         "src/main.tsx",
         "src/App.tsx",
         "src/FluidCanvas.tsx",
+        "src/fluid/doubleBuffer.ts",
         "src/fluid/gpu.ts",
         "src/fluid/resample.ts",
         "src/fluid/renderer.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
         "src/App.tsx",
         "src/FluidCanvas.tsx",
         "src/fluid/gpu.ts",
+        "src/fluid/resample.ts",
         "src/fluid/renderer.ts",
         "src/fluid/types.ts",
       ],


### PR DESCRIPTION
Closes #700.

## What changed

The settings panel gains two sliders for the grid resolutions that #699
deliberately held back — sim (64–512) and dye (256–2048).

They were held back because `resize` released the old textures before building
the new ones, so any resolution change blanked the velocity, pressure and dye
fields. `resize` now builds first, resamples the live velocity and dye onto the
new grids through a compute pass reusing `sampleAt`, and only then releases the
old set. Canvas resizes take the same path, so **they no longer clear the canvas
either** — a pre-existing behaviour this fixes on the way past.

Pressure is deliberately left behind: the Jacobi sweeps rebuild it from the
divergence within the frame, so carrying it buys nothing.

## The issue's four open questions, and the answer taken

| Question | Answer |
|---|---|
| Where the slider's value lands | A second channel (`ResolutionSettings`), keeping `FluidSettings`' next-frame-only contract honest, with its own `localStorage` key |
| One slider or two | Two — the grids are sized for different reasons, so a fixed-ratio quality dial would hide the trade the panel exists to offer |
| What the range is | **Not measured on a real device** — see below |
| Debounce | Commit on release, not per pointer move, since each committed value rebuilds every texture |

## Deliberately deferred

**The upper ends are not backed by an on-device measurement.** The issue asked
for one ("fill rate is what bounds it"), and it could not be run from the
development environment. 512 / 2048 bracket the current defaults rather than
tracking a measured ceiling. At dye 2048 on a 16:9 viewport the dye pair alone
is tens of MB of `rgba32float`, transiently doubled during a rebuild, so a
memory-tight GPU could plausibly hit device loss — and the app currently
dead-ends on the "GPU device was lost" notice with the oversized value still
persisted, so a reload rebuilds at the same resolution. Worth either measuring
the cap or adding a resolution fallback on device loss before the maxima are
treated as settled.

## Impact

No behaviour change at the default settings — the defaults are the constants
that were already compiled in. The transient cost is peak texture memory: both
resource sets are alive across one submit during a rebuild.

## Test plan

CI covers type-check, lint, unit (99 tests, 100% coverage on the non-GPU
modules) and the Playwright suite, so nothing below repeats it.

- [x] Verified the new e2e assertions actually fail when the behaviour they
      describe is removed: deleting the dye pair from `carryFields` drops mean
      brightness to a measured `0`; deleting the velocity pair drops
      frame-to-frame change to a measured `0` while brightness still passes;
      removing the `pointercancel` handler fails the cancelled-drag test.
- [ ] Fill-rate / memory ceiling at the maximum settings on a representative
      device — not run; see *Deliberately deferred*.
