### PR TITLE
Offer a resolution reset when the GPU fails, and record what the maxima cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,37 @@ onto cell faces, which advection and the splat would have to follow. Numbers and
 the options are in
 [#681](https://github.com/nemolize/dreamvision/issues/681).
 
+### What the resolution sliders cost
+
+The grids are the one setting that cannot take effect on the next frame:
+changing either rebuilds every texture. The rebuild builds the new set, carries
+the live velocity and dye onto it with a resample pass, and only then releases
+the old one — so the fields survive, at the cost of both sets being alive across
+one submit. Pressure is not carried; the Jacobi sweeps rebuild it within the
+frame.
+
+At the panel's maxima (sim 512, dye 2048) the textures come to ~83 MB on a 16:9
+viewport, transiently ~166 MB during a rebuild, against ~22 MB at the defaults.
+On an M-series Mac every step from the defaults to the maxima holds the display's
+120 Hz cap with no device loss, so nothing the panel offers saturates that
+machine; under the software renderer the Playwright suite uses — which does not
+hit a vsync cap, and so is the reading that separates the steps — the maxima cost
+about 2.2x the defaults per frame.
+
+Both readings are one machine each. A memory-tight GPU may still lose the device
+at a raised setting, so the notice that reports a lost device offers to reset the
+resolution and reload — the stored value is what the next load rebuilds at, and
+without that the notice would be a dead end.
+
 ## Project layout
 
 - `src/fluid/` — the simulation: WGSL shaders, the WebGPU pipeline setup
   (`renderer.ts`), device acquisition (`gpu.ts`), and pointer tracking
 - `src/FluidCanvas.tsx` — the canvas host; owns the animation loop, and holds
-  the settings the panel edits alongside an error message
+  the settings the panel edits alongside any failure to report
 - `src/SettingsPanel.tsx` — the collapsible panel of solver controls
+- `src/GpuNotice.tsx` — what replaces the canvas when the GPU fails, including
+  the offer to reset the resolution
 - `e2e-tests/` — Playwright specs, including one that drags across the canvas
   and asserts pixels actually light up
 

--- a/e2e-tests/index.spec.ts
+++ b/e2e-tests/index.spec.ts
@@ -287,6 +287,45 @@ test.describe("fluid canvas", () => {
     expect(changed).toBeGreaterThan(0.002);
   });
 
+  test("keeps simulating at the highest resolution the panel offers", async ({
+    page,
+  }) => {
+    // Raised because each canvas read is a screenshot, which costs seconds
+    // against CI's software renderer — the default 30s ceiling is not enough.
+    test.setTimeout(180_000);
+
+    await page.goto("/?seed=off");
+    await page.evaluate(() => {
+      window.localStorage.clear();
+    });
+    await page.goto("/?seed=off");
+    await expect(page.getByRole("alert")).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Open settings" }).click();
+    const sim = page.getByRole("slider", { name: "Sim grid" });
+    const dye = page.getByRole("slider", { name: "Dye grid" });
+    await settleSlider(
+      page,
+      "Sim grid",
+      (await sim.getAttribute("max")) ?? "512",
+    );
+    await settleSlider(
+      page,
+      "Dye grid",
+      (await dye.getAttribute("max")) ?? "2048",
+    );
+
+    const viewport = page.viewportSize() ?? { width: 1280, height: 720 };
+    await stir(page, viewport);
+
+    // The maxima are the one pair of values nothing else exercises, and the
+    // device that cannot hold them fails here rather than in someone's browser.
+    await expect(page.getByRole("alert")).toHaveCount(0);
+    await expect
+      .poll(() => litFraction(page), { timeout: 60_000 })
+      .toBeGreaterThan(0.01);
+  });
+
   test("restores a changed resolution after a reload", async ({ page }) => {
     await page.goto("/");
     await page.evaluate(() => {

--- a/src/FluidCanvas.tsx
+++ b/src/FluidCanvas.tsx
@@ -5,7 +5,7 @@ import { GpuUnavailableError, initGpu } from "@/fluid/gpu";
 import { PointerTracker } from "@/fluid/pointer";
 import { createFluidRenderer } from "@/fluid/renderer";
 import type { ResolutionSettings } from "@/fluid/resolution";
-import { DEFAULT_RESOLUTION } from "@/fluid/resolution";
+import { DEFAULT_RESOLUTION, sameResolution } from "@/fluid/resolution";
 import { seedEnabled, seedSplats } from "@/fluid/seed";
 import type { FluidSettings } from "@/fluid/settings";
 import { DEFAULT_SETTINGS } from "@/fluid/settings";
@@ -16,6 +16,7 @@ import {
   saveSettings,
 } from "@/fluid/settingsStorage";
 import type { FluidRenderer, Splat } from "@/fluid/types";
+import { GpuNotice } from "@/GpuNotice";
 import { SettingsPanel } from "@/SettingsPanel";
 
 /** Cap the backing store on high-DPI displays: past 2x the extra pixels cost
@@ -26,7 +27,12 @@ const SAVE_DEBOUNCE_MS = 200;
 
 export const FluidCanvas = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const [error, setError] = useState<string | null>(null);
+  // Two fields rather than one message, because whether the resolution is worth
+  // offering to reset is decided where the failure is caught, not where it renders.
+  const [failure, setFailure] = useState<{
+    message: string;
+    resolutionSuspect: boolean;
+  } | null>(null);
   const [settings, setSettings] = useState<FluidSettings>(loadSettings);
   const [resolution, setResolution] =
     useState<ResolutionSettings>(loadResolution);
@@ -142,7 +148,18 @@ export const FluidCanvas = () => {
       void device.lost.then((info) => {
         if (disposed || info.reason === "destroyed") return;
         cancelAnimationFrame(frameId);
-        setError("The GPU device was lost. Reload to restart the simulation.");
+        // A device lost at a raised resolution otherwise dead-ends: the value is
+        // already persisted, so every reload rebuilds at the size that lost it.
+        const suspect = !sameResolution(
+          resolutionRef.current,
+          DEFAULT_RESOLUTION,
+        );
+        setFailure({
+          message: suspect
+            ? "The GPU device was lost. The grid resolution may be more than this device can hold."
+            : "The GPU device was lost. Reload to restart the simulation.",
+          resolutionSuspect: suspect,
+        });
       });
 
       const { width, height } = resizeCanvas();
@@ -199,11 +216,17 @@ export const FluidCanvas = () => {
 
     void start().catch((cause: unknown) => {
       if (disposed) return;
-      setError(
-        cause instanceof GpuUnavailableError
+      // A raised resolution can fail the build itself, not only the running
+      // device, and lands in the same reload loop — so it gets the same escape.
+      const unavailable = cause instanceof GpuUnavailableError;
+      setFailure({
+        message: unavailable
           ? cause.message
           : "The simulation could not start on this device.",
-      );
+        resolutionSuspect:
+          !unavailable &&
+          !sameResolution(resolutionRef.current, DEFAULT_RESOLUTION),
+      });
     });
 
     return () => {
@@ -221,11 +244,17 @@ export const FluidCanvas = () => {
     };
   }, []);
 
-  if (error !== null) {
+  if (failure !== null) {
     return (
-      <p className="notice" role="alert">
-        {error}
-      </p>
+      <GpuNotice
+        message={failure.message}
+        {...(failure.resolutionSuspect && {
+          onResetResolution: () => {
+            saveResolution(DEFAULT_RESOLUTION);
+            window.location.reload();
+          },
+        })}
+      />
     );
   }
 

--- a/src/GpuNotice.test.tsx
+++ b/src/GpuNotice.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GpuNotice } from "@/GpuNotice";
+
+afterEach(cleanup);
+
+describe("GpuNotice", () => {
+  it("announces the failure, so a frozen canvas is not the only signal", () => {
+    render(<GpuNotice message="The GPU device was lost." />);
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "The GPU device was lost.",
+    );
+  });
+
+  it("offers no reset when the caller judged the resolution innocent", () => {
+    render(<GpuNotice message="The GPU device was lost." />);
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("offers the reset when the caller judged the resolution suspect", async () => {
+    const onResetResolution = vi.fn();
+    render(
+      <GpuNotice
+        message="The GPU device was lost."
+        onResetResolution={onResetResolution}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Reset resolution and reload" }),
+    );
+
+    // The stored resolution is what a reload would rebuild at, so without this
+    // the notice is a dead end rather than a way out.
+    expect(onResetResolution).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/GpuNotice.tsx
+++ b/src/GpuNotice.tsx
@@ -1,0 +1,21 @@
+interface GpuNoticeProps {
+  message: string;
+  /** Omitted when the resolution is already the default, where resetting it
+   * would change nothing and the offer would misdirect the reader. */
+  onResetResolution?: () => void;
+}
+
+export const GpuNotice = ({ message, onResetResolution }: GpuNoticeProps) => (
+  <p className="notice" role="alert">
+    {message}
+    {onResetResolution !== undefined && (
+      <button
+        type="button"
+        className="notice__action"
+        onClick={onResetResolution}
+      >
+        Reset resolution and reload
+      </button>
+    )}
+  </p>
+);

--- a/src/fluid/renderer.ts
+++ b/src/fluid/renderer.ts
@@ -8,6 +8,7 @@ import renderShaderSource from "./render.wgsl?raw";
 import type { ResampleField } from "./resample";
 import { createFieldResampler } from "./resample";
 import type { ResolutionSettings } from "./resolution";
+import { sameResolution } from "./resolution";
 import type { FluidSettings } from "./settings";
 import { DEFAULT_SETTINGS } from "./settings";
 import simulationShaderSource from "./simulation.wgsl?raw";
@@ -488,12 +489,7 @@ export const createFluidRenderer = (
   };
 
   const setResolution = (next: ResolutionSettings): void => {
-    if (
-      next.simResolution === resolution.simResolution &&
-      next.dyeResolution === resolution.dyeResolution
-    ) {
-      return;
-    }
+    if (sameResolution(next, resolution)) return;
     resolution = next;
     rebuild(canvasSize.width, canvasSize.height);
   };

--- a/src/fluid/resolution.test.ts
+++ b/src/fluid/resolution.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_RESOLUTION,
   normaliseResolution,
   RESOLUTION_DESCRIPTORS,
+  sameResolution,
 } from "./resolution";
 
 describe("RESOLUTION_DESCRIPTORS", () => {
@@ -36,6 +37,29 @@ describe("clampResolution", () => {
     expect(clampResolution("simResolution", Number.NaN)).toBe(
       DEFAULT_RESOLUTION.simResolution,
     );
+  });
+});
+
+describe("sameResolution", () => {
+  it("compares by value, since every caller holds a fresh object", () => {
+    expect(sameResolution(DEFAULT_RESOLUTION, { ...DEFAULT_RESOLUTION })).toBe(
+      true,
+    );
+  });
+
+  it("separates on either axis alone", () => {
+    expect(
+      sameResolution(DEFAULT_RESOLUTION, {
+        ...DEFAULT_RESOLUTION,
+        simResolution: 128,
+      }),
+    ).toBe(false);
+    expect(
+      sameResolution(DEFAULT_RESOLUTION, {
+        ...DEFAULT_RESOLUTION,
+        dyeResolution: 512,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/fluid/resolution.ts
+++ b/src/fluid/resolution.ts
@@ -37,6 +37,12 @@ export const RESOLUTION_DESCRIPTORS: readonly SettingDescriptor<
   },
 ];
 
+export const sameResolution = (
+  a: ResolutionSettings,
+  b: ResolutionSettings,
+): boolean =>
+  a.simResolution === b.simResolution && a.dyeResolution === b.dyeResolution;
+
 const resolution = describeSettings(RESOLUTION_DESCRIPTORS, DEFAULT_RESOLUTION);
 
 export const clampResolution = resolution.clamp;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -118,8 +118,10 @@ canvas {
 .notice {
   display: flex;
   height: 100%;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 1.25rem;
   margin: 0;
   padding: 2rem;
   color: #9aa0a6;
@@ -127,4 +129,18 @@ canvas {
     1rem/1.6 system-ui,
     sans-serif;
   text-align: center;
+}
+
+.notice__action {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ffffff2e;
+  border-radius: 0.375rem;
+  background: #ffffff0a;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.notice__action:hover {
+  background: #ffffff14;
 }


### PR DESCRIPTION
Closes the two items #701 left open under *Deliberately deferred*.

## The dead end

A device lost at a raised grid resolution had no way out from inside the app.
The value was already persisted, so the notice said "reload to restart" and the
reload rebuilt at the size that lost the device — the same notice again. Clearing
`localStorage` by hand was the only escape.

The notice now offers **Reset resolution and reload**, on the lost-device path
and on a start that fails outright (a raised resolution can fail the build
itself, and lands in the same loop). It offers this only when a non-default
resolution was live: resetting one already at the default changes nothing and
would send the reader after the wrong cause.

`sameResolution` moves into `resolution.ts` for that check, replacing the
renderer's own inline copy of the same comparison.

The notice moves into `GpuNotice.tsx` so the escape can be tested. `FluidCanvas`
needs a real adapter and is coverage-excluded, which is exactly what left this
path reachable only by reading it.

## The measurement #701 asked for

The issue wanted the upper end measured rather than picked. Two readings, one
machine each — stated as such in the README rather than as a settled ceiling:

| | defaults (320 / 1024) | maxima (512 / 2048) |
|---|---|---|
| Textures, 16:9 | ~22 MB | ~83 MB |
| Transient, during a rebuild | ~45 MB | ~166 MB |
| M-series Mac, real GPU | 120 fps | 120 fps, no device loss |
| Software renderer (no vsync cap) | baseline | ~2.2x the per-frame cost |

Every step from the defaults to the maxima holds the display's 120 Hz cap on the
M-series machine, so nothing the panel offers saturates it. The software-renderer
figure is the one that separates the steps, because it is not sitting on a cap —
that is the instrument check behind quoting both.

A new e2e drives the panel's maxima and asserts the canvas is still simulating
with no alert, so a device that cannot hold them fails in CI rather than in
someone's browser.

**The maxima are kept at 512 / 2048.** Neither reading argues for lowering them,
and a memory-tight GPU now has the escape hatch rather than a dead end.

## Impact

No behaviour change unless the GPU fails. The failure notice gains a button on
the paths where the stored resolution could plausibly be the cause.

## Test plan

CI covers type-check, lint, unit (104 tests, 100% coverage on the non-GPU
modules) and the Playwright suite, so nothing below repeats it.

- [x] Verified the new assertions fail when the behaviour they describe is
      removed: hiding the reset button fails the `GpuNotice` escape test.
- [x] Ran the maxima e2e against the real GPU as well as the software renderer.
- [ ] The `device.lost` wiring in `FluidCanvas` itself — still uncovered, like
      the rest of that file; only the notice it renders is tested.
