### PR TITLE
fix: key pointer strokes by id so two fingers paint two trails

### DIFF
--- a/src/FluidCanvas.tsx
+++ b/src/FluidCanvas.tsx
@@ -110,15 +110,15 @@ export const FluidCanvas = () => {
 
     const onPointerDown = (event: PointerEvent): void => {
       const [x, y] = toNormalised(event);
-      pointer.press(x, y);
+      pointer.press(event.pointerId, x, y);
       canvas.setPointerCapture(event.pointerId);
     };
     const onPointerMove = (event: PointerEvent): void => {
       const [x, y] = toNormalised(event);
-      pointer.move(x, y);
+      pointer.move(event.pointerId, x, y);
     };
-    const onPointerUp = (): void => {
-      pointer.release();
+    const onPointerUp = (event: PointerEvent): void => {
+      pointer.release(event.pointerId);
     };
 
     const resizeCanvas = (): { width: number; height: number } => {
@@ -198,8 +198,7 @@ export const FluidCanvas = () => {
         );
         owed -= steps * TIME_STEP;
 
-        const dragged = pointer.consume();
-        if (dragged !== null) pending.push(dragged);
+        pending.push(...pointer.consume());
 
         for (let step = 0; step < steps; step++) {
           // Drained into the first step that runs: replaying the frame's splats

--- a/src/fluid/config.ts
+++ b/src/fluid/config.ts
@@ -31,9 +31,8 @@ export const SPLAT_RADIUS = 0.0035;
 /** Scales normalised pointer motion into the velocity written to the field. */
 export const SPLAT_FORCE = 30;
 
-/** Ceiling on splats injected in one frame. The seed burst is the only thing
- * that approaches it; the cap bounds the uniform buffer the splat pass indexes
- * into, so anything beyond it is dropped rather than read out of range. */
+/** Bounds the uniform buffer the splat pass indexes into, so anything beyond
+ * it is dropped rather than read out of range. */
 export const MAX_SPLATS_PER_FRAME = 32;
 
 /** Splats injected once at startup, so the canvas opens mid-motion instead of

--- a/src/fluid/pointer.test.ts
+++ b/src/fluid/pointer.test.ts
@@ -4,8 +4,6 @@ import { SPLAT_FORCE } from "./config";
 import { PointerTracker } from "./pointer";
 import type { Splat } from "./types";
 
-/** Narrow away the "nothing to splat" case, so a test asserting on a splat's
- * contents fails loudly rather than on a property of `undefined`. */
 const only = (splats: readonly Splat[]): Splat => {
   const [first] = splats;
   if (splats.length !== 1 || first === undefined) {

--- a/src/fluid/pointer.test.ts
+++ b/src/fluid/pointer.test.ts
@@ -5,30 +5,33 @@ import { PointerTracker } from "./pointer";
 import type { Splat } from "./types";
 
 /** Narrow away the "nothing to splat" case, so a test asserting on a splat's
- * contents fails loudly rather than on a property of `null`. */
-const splatted = (splat: Splat | null): Splat => {
-  if (splat === null) throw new Error("expected a splat, got none");
-  return splat;
+ * contents fails loudly rather than on a property of `undefined`. */
+const only = (splats: readonly Splat[]): Splat => {
+  const [first] = splats;
+  if (splats.length !== 1 || first === undefined) {
+    throw new Error(`expected exactly one splat, got ${String(splats.length)}`);
+  }
+  return first;
 };
 
 describe("PointerTracker", () => {
   it("produces no splat before any interaction", () => {
-    expect(new PointerTracker().consume()).toBeNull();
+    expect(new PointerTracker().consume()).toEqual([]);
   });
 
   it("ignores movement while the pointer is up", () => {
     const tracker = new PointerTracker();
-    tracker.move(0.5, 0.5);
-    expect(tracker.consume()).toBeNull();
+    tracker.move(1, 0.5, 0.5);
+    expect(tracker.consume()).toEqual([]);
   });
 
   it("accumulates motion across several moves within one frame", () => {
     const tracker = new PointerTracker();
-    tracker.press(0.5, 0.5);
-    tracker.move(0.6, 0.5);
-    tracker.move(0.7, 0.5);
+    tracker.press(1, 0.5, 0.5);
+    tracker.move(1, 0.6, 0.5);
+    tracker.move(1, 0.7, 0.5);
 
-    const sample = splatted(tracker.consume());
+    const sample = only(tracker.consume());
     expect(sample.x).toBeCloseTo(0.7, 6);
     // Both steps contribute, so the force is the whole 0.5 -> 0.7 travel.
     expect(sample.dx).toBeCloseTo(0.2 * SPLAT_FORCE, 3);
@@ -37,13 +40,13 @@ describe("PointerTracker", () => {
 
   it("clears motion once consumed so a still pointer applies no force", () => {
     const tracker = new PointerTracker();
-    tracker.press(0.5, 0.5);
-    tracker.move(0.6, 0.5);
+    tracker.press(1, 0.5, 0.5);
+    tracker.move(1, 0.6, 0.5);
     tracker.consume();
 
     // A held pointer still splats — at zero force, so it only keeps feeding
     // colour at rest.
-    const sample = splatted(tracker.consume());
+    const sample = only(tracker.consume());
     expect(sample.dx).toBe(0);
     expect(sample.dy).toBe(0);
     expect(sample.x).toBeCloseTo(0.6, 6);
@@ -51,54 +54,127 @@ describe("PointerTracker", () => {
 
   it("stops splatting after release", () => {
     const tracker = new PointerTracker();
-    tracker.press(0.5, 0.5);
-    tracker.release();
-    tracker.move(0.9, 0.9);
+    tracker.press(1, 0.5, 0.5);
+    tracker.release(1);
+    tracker.move(1, 0.9, 0.9);
 
-    expect(tracker.consume()).toBeNull();
+    expect(tracker.consume()).toEqual([]);
   });
 
   it("still splats a drag that began and ended between two frames", () => {
     const tracker = new PointerTracker();
-    tracker.press(0.2, 0.5);
-    tracker.move(0.6, 0.5);
-    tracker.release();
+    tracker.press(1, 0.2, 0.5);
+    tracker.move(1, 0.6, 0.5);
+    tracker.release(1);
 
     // The button is already up, but this motion has never been rendered —
     // dropping it would lose the whole drag.
-    const sample = splatted(tracker.consume());
+    const sample = only(tracker.consume());
     expect(sample.x).toBeCloseTo(0.6, 6);
     expect(sample.dx).toBeCloseTo(0.4 * SPLAT_FORCE, 3);
 
     // Drained: the next frame must not splat the same motion again.
-    expect(tracker.consume()).toBeNull();
+    expect(tracker.consume()).toEqual([]);
   });
 
   it("scales the splat by the force set on it", () => {
     const tracker = new PointerTracker();
     tracker.setForce(10);
-    tracker.press(0.5, 0.5);
-    tracker.move(0.6, 0.5);
+    tracker.press(1, 0.5, 0.5);
+    tracker.move(1, 0.6, 0.5);
 
-    expect(splatted(tracker.consume()).dx).toBeCloseTo(0.1 * 10, 6);
+    expect(only(tracker.consume()).dx).toBeCloseTo(0.1 * 10, 6);
   });
 
   it("applies a force changed mid-drag to the motion already accumulated", () => {
     const tracker = new PointerTracker();
     tracker.setForce(10);
-    tracker.press(0.5, 0.5);
-    tracker.move(0.6, 0.5);
+    tracker.press(1, 0.5, 0.5);
+    tracker.move(1, 0.6, 0.5);
     tracker.setForce(20);
 
-    expect(splatted(tracker.consume()).dx).toBeCloseTo(0.1 * 20, 6);
+    expect(only(tracker.consume()).dx).toBeCloseTo(0.1 * 20, 6);
   });
 
-  it("does not carry motion across a press", () => {
+  it("does not carry motion across a re-press of the same pointer", () => {
     const tracker = new PointerTracker();
-    tracker.press(0.1, 0.1);
-    tracker.move(0.4, 0.1);
-    tracker.press(0.8, 0.8);
+    tracker.press(1, 0.1, 0.1);
+    tracker.move(1, 0.4, 0.1);
+    tracker.press(1, 0.8, 0.8);
 
-    expect(tracker.consume()).toMatchObject({ x: 0.8, y: 0.8, dx: 0, dy: 0 });
+    expect(only(tracker.consume())).toMatchObject({
+      x: 0.8,
+      y: 0.8,
+      dx: 0,
+      dy: 0,
+    });
+  });
+
+  it("splats each pressed pointer separately", () => {
+    const tracker = new PointerTracker();
+    tracker.press(1, 0.2, 0.2);
+    tracker.press(2, 0.8, 0.8);
+    tracker.move(1, 0.3, 0.2);
+    tracker.move(2, 0.8, 0.6);
+
+    const splats = tracker.consume();
+    expect(splats).toHaveLength(2);
+    expect(splats[0]).toMatchObject({ x: 0.3, y: 0.2 });
+    expect(splats[0]?.dx).toBeCloseTo(0.1 * SPLAT_FORCE, 3);
+    expect(splats[1]).toMatchObject({ x: 0.8, y: 0.6 });
+    expect(splats[1]?.dy).toBeCloseTo(-0.2 * SPLAT_FORCE, 3);
+  });
+
+  it("leaves a live stroke untouched when another pointer presses", () => {
+    const tracker = new PointerTracker();
+    tracker.press(1, 0.2, 0.5);
+    tracker.move(1, 0.4, 0.5);
+    tracker.press(2, 0.9, 0.9);
+
+    const first = tracker.consume().find((splat) => splat.x === 0.4);
+    expect(first?.dx).toBeCloseTo(0.2 * SPLAT_FORCE, 3);
+  });
+
+  it("keeps a held pointer splatting after another pointer is released", () => {
+    const tracker = new PointerTracker();
+    tracker.press(1, 0.2, 0.5);
+    tracker.press(2, 0.9, 0.9);
+    tracker.release(2);
+    tracker.consume();
+
+    tracker.move(1, 0.5, 0.5);
+    const sample = only(tracker.consume());
+    expect(sample.x).toBeCloseTo(0.5, 6);
+    expect(sample.dx).toBeCloseTo(0.3 * SPLAT_FORCE, 3);
+  });
+
+  it("gives each pointer its own colour", () => {
+    const tracker = new PointerTracker();
+    tracker.press(1, 0.2, 0.2);
+    tracker.press(2, 0.8, 0.8);
+
+    const splats = tracker.consume();
+    // Colours are random, so this asserts they are drawn per stroke rather
+    // than shared by reference — not that the two values differ.
+    expect(splats[0]?.color).not.toBe(splats[1]?.color);
+  });
+
+  it("ignores a release for a pointer it never saw", () => {
+    const tracker = new PointerTracker();
+    tracker.press(1, 0.5, 0.5);
+    tracker.release(99);
+
+    expect(only(tracker.consume()).x).toBeCloseTo(0.5, 6);
+  });
+
+  it("drops a released stroke rather than retaining it per touch", () => {
+    const tracker = new PointerTracker();
+    for (let id = 0; id < 50; id++) {
+      tracker.press(id, 0.5, 0.5);
+      tracker.release(id);
+      tracker.consume();
+    }
+
+    expect(tracker.consume()).toEqual([]);
   });
 });

--- a/src/fluid/pointer.ts
+++ b/src/fluid/pointer.ts
@@ -8,8 +8,6 @@ interface Stroke {
   dx: number;
   dy: number;
   active: boolean;
-  /** Motion arrived since the last `consume`, so it is still unsplatted even
-   * if the pointer has been released since. */
   pending: boolean;
   color: readonly [number, number, number];
 }
@@ -62,8 +60,6 @@ export class PointerTracker {
 
     for (const [id, stroke] of this.strokes) {
       if (!stroke.active && !stroke.pending) {
-        // Nothing more will ever come from this id, and an ended stroke left in
-        // the map would leak one entry per touch.
         this.strokes.delete(id);
         continue;
       }

--- a/src/fluid/pointer.ts
+++ b/src/fluid/pointer.ts
@@ -2,64 +2,84 @@ import { randomColor } from "./color";
 import { SPLAT_FORCE } from "./config";
 import type { Splat } from "./types";
 
-/**
- * Tracks the pointer in normalised canvas space and produces the per-frame
- * splat input. Deliberately not React state: it changes on every pointermove
- * and nothing in the tree renders from it.
- */
-export class PointerTracker {
-  private x = 0;
-  private y = 0;
-  private dx = 0;
-  private dy = 0;
-  private active = false;
+interface Stroke {
+  x: number;
+  y: number;
+  dx: number;
+  dy: number;
+  active: boolean;
   /** Motion arrived since the last `consume`, so it is still unsplatted even
    * if the pointer has been released since. */
-  private pending = false;
-  private color = randomColor();
+  pending: boolean;
+  color: readonly [number, number, number];
+}
+
+/**
+ * Deliberately not React state: it changes on every pointermove and nothing in
+ * the tree renders from it. Keyed by `pointerId` because one shared stroke let
+ * a second finger's press teleport the first and its release end a live drag.
+ */
+export class PointerTracker {
+  private strokes = new Map<number, Stroke>();
   private force = SPLAT_FORCE;
 
   setForce(force: number): void {
     this.force = force;
   }
 
-  press(x: number, y: number): void {
-    this.x = x;
-    this.y = y;
-    this.dx = 0;
-    this.dy = 0;
-    this.active = true;
-    this.color = randomColor();
+  press(id: number, x: number, y: number): void {
+    this.strokes.set(id, {
+      x,
+      y,
+      dx: 0,
+      dy: 0,
+      active: true,
+      pending: false,
+      color: randomColor(),
+    });
   }
 
-  move(x: number, y: number): void {
-    if (!this.active) return;
-    this.dx += x - this.x;
-    this.dy += y - this.y;
-    this.x = x;
-    this.y = y;
-    this.pending = true;
+  move(id: number, x: number, y: number): void {
+    const stroke = this.strokes.get(id);
+    if (stroke?.active !== true) return;
+    stroke.dx += x - stroke.x;
+    stroke.dy += y - stroke.y;
+    stroke.x = x;
+    stroke.y = y;
+    stroke.pending = true;
   }
 
-  release(): void {
-    this.active = false;
+  release(id: number): void {
+    const stroke = this.strokes.get(id);
+    if (stroke !== undefined) stroke.active = false;
   }
 
-  /** Read the frame's input and clear it. A drag that began and ended between
-   * two frames still yields a splat — its motion has never been rendered. */
-  consume(): Splat | null {
-    if (!this.active && !this.pending) return null;
+  /** A released stroke is still drained once, because a drag that began and
+   * ended between two frames has never been rendered and dropping it would lose
+   * the whole gesture. */
+  consume(): Splat[] {
+    const splats: Splat[] = [];
 
-    const splat: Splat = {
-      x: this.x,
-      y: this.y,
-      dx: this.dx * this.force,
-      dy: this.dy * this.force,
-      color: this.color,
-    };
-    this.dx = 0;
-    this.dy = 0;
-    this.pending = false;
-    return splat;
+    for (const [id, stroke] of this.strokes) {
+      if (!stroke.active && !stroke.pending) {
+        // Nothing more will ever come from this id, and an ended stroke left in
+        // the map would leak one entry per touch.
+        this.strokes.delete(id);
+        continue;
+      }
+
+      splats.push({
+        x: stroke.x,
+        y: stroke.y,
+        dx: stroke.dx * this.force,
+        dy: stroke.dy * this.force,
+        color: stroke.color,
+      });
+      stroke.dx = 0;
+      stroke.dy = 0;
+      stroke.pending = false;
+    }
+
+    return splats;
   }
 }


### PR DESCRIPTION
## What changed

`PointerTracker` now keys its strokes by `pointerId`, and `consume()` returns one splat per pressed pointer instead of a single `Splat | null`.

## Why

The tracker held one unkeyed stroke and `FluidCanvas` fed every pointer into it, so on a touch device:

- a second finger's press teleported the first finger's stroke to the new coordinates and discarded the travel it had accumulated;
- that second finger's release cleared `active`, so the first finger — still pressed — stopped producing splats for the rest of its drag.

The canvas sets `touch-action: none` precisely to own touch drags, so dragging is the primary interaction on mobile and this broke it.

## Impact

Two fingers now paint two trails, each with its own colour. Mouse behaviour is unchanged — a single pointer takes the same path through the new map as it did through the old fields.

## Test plan

Nothing beyond CI. Alongside the existing eight tests (updated to pass an id), the suite gains seven covering the multi-touch paths: two pointers splatting separately, a live stroke surviving another pointer's press, a held pointer surviving another pointer's release, per-stroke colours, a release for an unknown id, and released strokes being dropped rather than retained per touch.

The new tests were checked against a mutant: reverting `move`/`release` to the shared-stroke behaviour this PR removes fails three of them.

## Deliberately out of scope

Keying by pointer means the producer can now emit more than one splat per frame, which makes #706's `MAX_SPLATS_PER_FRAME` overflow easier to reach. That issue is left open, with the measurements from this work — including why the obvious carry-the-overflow repair diverges and what bounds it instead — recorded there.

Closes #703
