### PR TITLE
fix: skip the resize rebuild when the grid dimensions are unchanged

### DIFF
--- a/src/fluid/grid.test.ts
+++ b/src/fluid/grid.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import { DYE_RESOLUTION, SIM_RESOLUTION, WORKGROUP_SIZE } from "./config";
 import type { Grid } from "./grid";
-import { dispatchSize, fitGrid, needsRebuild, sameGrid } from "./grid";
+import {
+  dispatchSize,
+  fitGrid,
+  fitGrids,
+  needsRebuild,
+  sameGrid,
+} from "./grid";
 import { RESOLUTION_DESCRIPTORS } from "./resolution";
 
 /** The extremes of a viewport, so a resolution the panel offers is checked
@@ -73,8 +79,6 @@ describe("sameGrid", () => {
   });
 
   it("is decided by the finer dye grid, so the sim grid alone overstates how often a resize can be skipped", () => {
-    // The renderer skips only when BOTH grids match, so the sim rate alone
-    // certifies a skip rate the guard never delivers.
     const rate = (
       steady: (width: number, height: number) => boolean,
     ): number => {
@@ -138,6 +142,21 @@ describe("needsRebuild", () => {
     expect(
       needsRebuild(pair(SIM, DYE), pair(SIM, { width: 1024, height: 575 })),
     ).toBe(true);
+  });
+
+  it("rebuilds on the first build, which has no grids to keep", () => {
+    expect(needsRebuild(null, pair(SIM, DYE))).toBe(true);
+  });
+
+  it("skips a 1px canvas step on a wide viewport but not the resize that changes a grid", () => {
+    const resolution = {
+      simResolution: SIM_RESOLUTION,
+      dyeResolution: DYE_RESOLUTION,
+    };
+    const built = fitGrids(3840, 800, resolution);
+
+    expect(needsRebuild(built, fitGrids(3841, 800, resolution))).toBe(false);
+    expect(needsRebuild(built, fitGrids(1920, 1080, resolution))).toBe(true);
   });
 });
 

--- a/src/fluid/grid.test.ts
+++ b/src/fluid/grid.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { SIM_RESOLUTION, WORKGROUP_SIZE } from "./config";
-import { dispatchSize, fitGrid, sameGrid } from "./grid";
+import { DYE_RESOLUTION, SIM_RESOLUTION, WORKGROUP_SIZE } from "./config";
+import type { Grid } from "./grid";
+import { dispatchSize, fitGrid, needsRebuild, sameGrid } from "./grid";
 import { RESOLUTION_DESCRIPTORS } from "./resolution";
 
 /** The extremes of a viewport, so a resolution the panel offers is checked
@@ -71,18 +72,72 @@ describe("sameGrid", () => {
     ).toBe(false);
   });
 
-  it("reports most 1px canvas steps as the same grid, which is what makes the resize guard worth having", () => {
-    let unchanged = 0;
-    let total = 0;
-    for (const { width, height } of VIEWPORTS) {
-      for (let step = 0; step < 40; step++) {
-        const settled = fitGrid(width + step, height, SIM_RESOLUTION);
-        const nudged = fitGrid(width + step + 1, height, SIM_RESOLUTION);
-        if (sameGrid(settled, nudged)) unchanged++;
-        total++;
+  it("is decided by the finer dye grid, so the sim grid alone overstates how often a resize can be skipped", () => {
+    // The renderer skips only when BOTH grids match, so the sim rate alone
+    // certifies a skip rate the guard never delivers.
+    const rate = (
+      steady: (width: number, height: number) => boolean,
+    ): number => {
+      let unchanged = 0;
+      let total = 0;
+      for (const { width, height } of VIEWPORTS) {
+        for (let step = 0; step < 40; step++) {
+          if (steady(width + step, height)) unchanged++;
+          total++;
+        }
       }
+      return unchanged / total;
+    };
+
+    const steadyAt =
+      (resolution: number) =>
+      (width: number, height: number): boolean =>
+        sameGrid(
+          fitGrid(width, height, resolution),
+          fitGrid(width + 1, height, resolution),
+        );
+
+    const simOnly = rate(steadyAt(SIM_RESOLUTION));
+    const bothGrids = rate(
+      (width, height) =>
+        steadyAt(SIM_RESOLUTION)(width, height) &&
+        steadyAt(DYE_RESOLUTION)(width, height),
+    );
+
+    expect(simOnly).toBeGreaterThan(0.8);
+    expect(bothGrids).toBeLessThan(simOnly);
+    expect(bothGrids).toBeGreaterThan(0.4);
+  });
+
+  it("never skips on a square viewport, where the dye grid steps on every pixel", () => {
+    for (let step = 0; step < 8; step++) {
+      const width = 1000 + step;
+      expect(
+        sameGrid(
+          fitGrid(width, 1000, DYE_RESOLUTION),
+          fitGrid(width + 1, 1000, DYE_RESOLUTION),
+        ),
+      ).toBe(false);
     }
-    expect(unchanged / total).toBeGreaterThan(0.5);
+  });
+});
+
+describe("needsRebuild", () => {
+  const pair = (sim: Grid, dye: Grid) => ({ simGrid: sim, dyeGrid: dye });
+  const SIM = { width: 320, height: 180 };
+  const DYE = { width: 1024, height: 576 };
+
+  it("skips the rebuild only when both grids match", () => {
+    expect(needsRebuild(pair(SIM, DYE), pair(SIM, DYE))).toBe(false);
+  });
+
+  it("rebuilds when either grid alone differs, since each sizes its own textures", () => {
+    expect(
+      needsRebuild(pair(SIM, DYE), pair({ width: 320, height: 179 }, DYE)),
+    ).toBe(true);
+    expect(
+      needsRebuild(pair(SIM, DYE), pair(SIM, { width: 1024, height: 575 })),
+    ).toBe(true);
   });
 });
 

--- a/src/fluid/grid.test.ts
+++ b/src/fluid/grid.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { WORKGROUP_SIZE } from "./config";
-import { dispatchSize, fitGrid } from "./grid";
+import { SIM_RESOLUTION, WORKGROUP_SIZE } from "./config";
+import { dispatchSize, fitGrid, sameGrid } from "./grid";
 import { RESOLUTION_DESCRIPTORS } from "./resolution";
 
 /** The extremes of a viewport, so a resolution the panel offers is checked
@@ -55,6 +55,34 @@ describe("fitGrid", () => {
         }
       }
     }
+  });
+});
+
+describe("sameGrid", () => {
+  it("compares the dimensions, not the identity", () => {
+    expect(
+      sameGrid({ width: 320, height: 180 }, { width: 320, height: 180 }),
+    ).toBe(true);
+    expect(
+      sameGrid({ width: 320, height: 180 }, { width: 320, height: 181 }),
+    ).toBe(false);
+    expect(
+      sameGrid({ width: 320, height: 180 }, { width: 321, height: 180 }),
+    ).toBe(false);
+  });
+
+  it("reports most 1px canvas steps as the same grid, which is what makes the resize guard worth having", () => {
+    let unchanged = 0;
+    let total = 0;
+    for (const { width, height } of VIEWPORTS) {
+      for (let step = 0; step < 40; step++) {
+        const settled = fitGrid(width + step, height, SIM_RESOLUTION);
+        const nudged = fitGrid(width + step + 1, height, SIM_RESOLUTION);
+        if (sameGrid(settled, nudged)) unchanged++;
+        total++;
+      }
+    }
+    expect(unchanged / total).toBeGreaterThan(0.5);
   });
 });
 

--- a/src/fluid/grid.ts
+++ b/src/fluid/grid.ts
@@ -31,9 +31,22 @@ export interface GridPair {
   dyeGrid: Grid;
 }
 
+export const fitGrids = (
+  width: number,
+  height: number,
+  resolution: { simResolution: number; dyeResolution: number },
+): GridPair => ({
+  simGrid: fitGrid(width, height, resolution.simResolution),
+  dyeGrid: fitGrid(width, height, resolution.dyeResolution),
+});
+
 /** Either grid differing means the textures it sizes are the wrong shape, so
- * both must match for the rebuild to be skippable. */
-export const needsRebuild = (current: GridPair, next: GridPair): boolean =>
+ * both must match to skip; `null` is the first build, with nothing to keep. */
+export const needsRebuild = (
+  current: GridPair | null,
+  next: GridPair,
+): boolean =>
+  current === null ||
   !sameGrid(next.simGrid, current.simGrid) ||
   !sameGrid(next.dyeGrid, current.dyeGrid);
 

--- a/src/fluid/grid.ts
+++ b/src/fluid/grid.ts
@@ -23,6 +23,9 @@ export const fitGrid = (
   };
 };
 
+export const sameGrid = (a: Grid, b: Grid): boolean =>
+  a.width === b.width && a.height === b.height;
+
 export const dispatchSize = (grid: Grid): [number, number] => [
   Math.ceil(grid.width / WORKGROUP_SIZE),
   Math.ceil(grid.height / WORKGROUP_SIZE),

--- a/src/fluid/grid.ts
+++ b/src/fluid/grid.ts
@@ -26,6 +26,17 @@ export const fitGrid = (
 export const sameGrid = (a: Grid, b: Grid): boolean =>
   a.width === b.width && a.height === b.height;
 
+export interface GridPair {
+  simGrid: Grid;
+  dyeGrid: Grid;
+}
+
+/** Either grid differing means the textures it sizes are the wrong shape, so
+ * both must match for the rebuild to be skippable. */
+export const needsRebuild = (current: GridPair, next: GridPair): boolean =>
+  !sameGrid(next.simGrid, current.simGrid) ||
+  !sameGrid(next.dyeGrid, current.dyeGrid);
+
 export const dispatchSize = (grid: Grid): [number, number] => [
   Math.ceil(grid.width / WORKGROUP_SIZE),
   Math.ceil(grid.height / WORKGROUP_SIZE),

--- a/src/fluid/renderer.ts
+++ b/src/fluid/renderer.ts
@@ -1,7 +1,7 @@
 import { MAX_SPLATS_PER_FRAME, TIME_STEP, WORKGROUP_SIZE } from "./config";
 import { DoubleBuffer } from "./doubleBuffer";
-import type { Grid, GridPair } from "./grid";
-import { dispatchSize, fitGrid, needsRebuild } from "./grid";
+import type { Grid } from "./grid";
+import { dispatchSize, fitGrids, needsRebuild } from "./grid";
 import type { ProjectionScale } from "./projection";
 import { projectionScale, projectionUniform } from "./projection";
 import renderShaderSource from "./render.wgsl?raw";
@@ -239,7 +239,6 @@ export const createFluidRenderer = (
   interface Resources {
     simGrid: Grid;
     dyeGrid: Grid;
-    /** Fixed by `simGrid`, so it is resolved once per rebuild. */
     scale: ProjectionScale;
     velocity: DoubleBuffer;
     dye: DoubleBuffer;
@@ -271,16 +270,15 @@ export const createFluidRenderer = (
   let resolution: ResolutionSettings = initialResolution;
   let canvasSize = { width, height };
 
-  const fitGrids = (canvasWidth: number, canvasHeight: number): GridPair => ({
-    simGrid: fitGrid(canvasWidth, canvasHeight, resolution.simResolution),
-    dyeGrid: fitGrid(canvasWidth, canvasHeight, resolution.dyeResolution),
-  });
-
   const buildResources = (
     canvasWidth: number,
     canvasHeight: number,
   ): Resources => {
-    const { simGrid, dyeGrid } = fitGrids(canvasWidth, canvasHeight);
+    const { simGrid, dyeGrid } = fitGrids(
+      canvasWidth,
+      canvasHeight,
+      resolution,
+    );
     const scale = projectionScale(simGrid.width, simGrid.height);
 
     const velocity = new DoubleBuffer(device, simGrid, VELOCITY_FORMAT);
@@ -483,10 +481,8 @@ export const createFluidRenderer = (
    * decides, and at a square aspect it steps every pixel, so this never fires. */
   const resize = (canvasWidth: number, canvasHeight: number): void => {
     canvasSize = { width: canvasWidth, height: canvasHeight };
-    const current = resources;
     if (
-      current !== null &&
-      !needsRebuild(current, fitGrids(canvasWidth, canvasHeight))
+      !needsRebuild(resources, fitGrids(canvasWidth, canvasHeight, resolution))
     ) {
       return;
     }

--- a/src/fluid/renderer.ts
+++ b/src/fluid/renderer.ts
@@ -1,7 +1,7 @@
 import { MAX_SPLATS_PER_FRAME, TIME_STEP, WORKGROUP_SIZE } from "./config";
 import { DoubleBuffer } from "./doubleBuffer";
 import type { Grid } from "./grid";
-import { dispatchSize, fitGrid } from "./grid";
+import { dispatchSize, fitGrid, sameGrid } from "./grid";
 import type { ProjectionScale } from "./projection";
 import { projectionScale, projectionUniform } from "./projection";
 import renderShaderSource from "./render.wgsl?raw";
@@ -271,20 +271,19 @@ export const createFluidRenderer = (
   let resolution: ResolutionSettings = initialResolution;
   let canvasSize = { width, height };
 
+  const fitGrids = (
+    canvasWidth: number,
+    canvasHeight: number,
+  ): { simGrid: Grid; dyeGrid: Grid } => ({
+    simGrid: fitGrid(canvasWidth, canvasHeight, resolution.simResolution),
+    dyeGrid: fitGrid(canvasWidth, canvasHeight, resolution.dyeResolution),
+  });
+
   const buildResources = (
     canvasWidth: number,
     canvasHeight: number,
   ): Resources => {
-    const simGrid = fitGrid(
-      canvasWidth,
-      canvasHeight,
-      resolution.simResolution,
-    );
-    const dyeGrid = fitGrid(
-      canvasWidth,
-      canvasHeight,
-      resolution.dyeResolution,
-    );
+    const { simGrid, dyeGrid } = fitGrids(canvasWidth, canvasHeight);
     const scale = projectionScale(simGrid.width, simGrid.height);
 
     const velocity = new DoubleBuffer(device, simGrid, VELOCITY_FORMAT);
@@ -483,8 +482,20 @@ export const createFluidRenderer = (
     resources = next;
   };
 
+  /** `fitGrid` quantises, so most of a window drag's observed sizes land on the
+   * grids already built — without this the rebuild above runs every frame. */
   const resize = (canvasWidth: number, canvasHeight: number): void => {
     canvasSize = { width: canvasWidth, height: canvasHeight };
+    const current = resources;
+    if (current !== null) {
+      const next = fitGrids(canvasWidth, canvasHeight);
+      if (
+        sameGrid(next.simGrid, current.simGrid) &&
+        sameGrid(next.dyeGrid, current.dyeGrid)
+      ) {
+        return;
+      }
+    }
     rebuild(canvasWidth, canvasHeight);
   };
 

--- a/src/fluid/renderer.ts
+++ b/src/fluid/renderer.ts
@@ -1,7 +1,7 @@
 import { MAX_SPLATS_PER_FRAME, TIME_STEP, WORKGROUP_SIZE } from "./config";
 import { DoubleBuffer } from "./doubleBuffer";
-import type { Grid } from "./grid";
-import { dispatchSize, fitGrid, sameGrid } from "./grid";
+import type { Grid, GridPair } from "./grid";
+import { dispatchSize, fitGrid, needsRebuild } from "./grid";
 import type { ProjectionScale } from "./projection";
 import { projectionScale, projectionUniform } from "./projection";
 import renderShaderSource from "./render.wgsl?raw";
@@ -239,7 +239,7 @@ export const createFluidRenderer = (
   interface Resources {
     simGrid: Grid;
     dyeGrid: Grid;
-    /** Fixed by the grid and the canvas, so resolved once per resize. */
+    /** Fixed by `simGrid`, so it is resolved once per rebuild. */
     scale: ProjectionScale;
     velocity: DoubleBuffer;
     dye: DoubleBuffer;
@@ -271,10 +271,7 @@ export const createFluidRenderer = (
   let resolution: ResolutionSettings = initialResolution;
   let canvasSize = { width, height };
 
-  const fitGrids = (
-    canvasWidth: number,
-    canvasHeight: number,
-  ): { simGrid: Grid; dyeGrid: Grid } => ({
+  const fitGrids = (canvasWidth: number, canvasHeight: number): GridPair => ({
     simGrid: fitGrid(canvasWidth, canvasHeight, resolution.simResolution),
     dyeGrid: fitGrid(canvasWidth, canvasHeight, resolution.dyeResolution),
   });
@@ -482,19 +479,16 @@ export const createFluidRenderer = (
     resources = next;
   };
 
-  /** `fitGrid` quantises, so most of a window drag's observed sizes land on the
-   * grids already built — without this the rebuild above runs every frame. */
+  /** Thins a drag's rebuild storm rather than stopping it: the finer dye grid
+   * decides, and at a square aspect it steps every pixel, so this never fires. */
   const resize = (canvasWidth: number, canvasHeight: number): void => {
     canvasSize = { width: canvasWidth, height: canvasHeight };
     const current = resources;
-    if (current !== null) {
-      const next = fitGrids(canvasWidth, canvasHeight);
-      if (
-        sameGrid(next.simGrid, current.simGrid) &&
-        sameGrid(next.dyeGrid, current.dyeGrid)
-      ) {
-        return;
-      }
+    if (
+      current !== null &&
+      !needsRebuild(current, fitGrids(canvasWidth, canvasHeight))
+    ) {
+      return;
     }
     rebuild(canvasWidth, canvasHeight);
   };


### PR DESCRIPTION
`resize()` rebuilt every texture unconditionally, while its sibling `setResolution()` guarded on equality. `fitGrid` quantises with `Math.round`, so a 1px canvas change often yields the identical grid — and dragging a window edge still ran a full destroy / recreate / resample cycle per animation frame, each transiently doubling texture memory across the one submit where both field sets are alive.

The guard now compares the newly fitted grids against the live ones and returns early when both match.

## What the guard is worth

It thins the rebuild storm rather than stopping it, and the numbers are pinned in `grid.test.ts` rather than asserted in prose:

| Case | Skip rate |
|---|---|
| Sim grid alone (misleading) | 0.835 |
| Both grids — what the guard delivers | 0.445 |
| Square viewport | never skips |

The dye grid quantises ~3x finer than the sim grid, so it decides. At a square aspect its short axis steps on every pixel and the guard cannot fire at all. The `resize` doc comment states both limits.

## Known gap

The call site's polarity is not pinned by any test: inverting `!needsRebuild(...)` — so the renderer skips exactly when a rebuild **is** needed — leaves all 117 tests green. `needsRebuild` itself is covered, including the `&&`/`||` mutation, but the substitution at the call site is not.

Pinning it needs a stubbed `GPUDevice`. I wrote that test and it did catch the inversion, but it needs type assertions to build the stub, which `@typescript-eslint/consistent-type-assertions` forbids repo-wide. The twin `setResolution` guard is unpinned for the same reason, so this matches the existing state rather than adding a new gap. Worth its own issue alongside #709 if the `FluidCanvas` lifecycle gets a test harness.

Closes #704

## Test plan

Nothing beyond CI.
