### PR TITLE
fix: release pointer capture and treat lostpointercapture as a release

### DIFF
--- a/e2e-tests/index.spec.ts
+++ b/e2e-tests/index.spec.ts
@@ -432,13 +432,17 @@ test.describe("fluid canvas", () => {
     await hideSettings(page);
 
     const viewport = page.viewportSize() ?? { width: 1280, height: 720 };
-    const midY = viewport.height / 2;
-    // Abandoned mid-canvas, away from the edges, because the ring sampled around
+    // Abandoned mid-canvas, away from the edges, because the disc sampled around
     // it has to stay on the canvas in every direction.
     const abandoned = { x: 0.5, y: 0.5 };
-    await page.mouse.move(viewport.width * 0.3, midY);
+    const at = (point: { x: number; y: number }): [number, number] => [
+      viewport.width * point.x,
+      viewport.height * point.y,
+    ];
+
+    await page.mouse.move(...at({ x: 0.3, y: abandoned.y }));
     await page.mouse.down();
-    await page.mouse.move(viewport.width * abandoned.x, midY, { steps: 6 });
+    await page.mouse.move(...at(abandoned), { steps: 6 });
 
     // Dispatched by hand because Playwright's mouse cannot revoke a capture; the
     // id must be its own 1, since PointerEvent's default 0 matches no stroke.
@@ -461,17 +465,26 @@ test.describe("fluid canvas", () => {
     /* eslint-enable playwright/no-wait-for-timeout */
     const after = await sampleCanvas(page);
 
+    const sum = (pixels: number[]): number =>
+      pixels.reduce((total, value) => total + value, 0);
+    const localBefore = meanAround(before, abandoned, 0.06);
+
+    // Asserted before the ratio because every degenerate reading divides out to
+    // 1 and passes: an unpainted drag would otherwise verify nothing at all.
+    expect(localBefore).toBeGreaterThan(0);
+    expect(sum(before)).toBeGreaterThan(0);
+
     // Compared against the field's own growth because dye keeps spreading
     // either way — an absolute rise fires on both the fixed and broken builds.
-    const sum = (pixels: number[]): number =>
-      pixels.reduce((total, value) => total + value, 0) || 1;
-    const localGrowth =
-      meanAround(after, abandoned, 0.06) / meanAround(before, abandoned, 0.06);
+    const localGrowth = meanAround(after, abandoned, 0.06) / localBefore;
     const fieldGrowth = sum(after) / sum(before);
 
     // A stranded stroke re-splats its last position every frame, so its dye
     // piles up there faster than the field as a whole moves.
-    expect(localGrowth).toBeLessThan(fieldGrowth * 1.3);
+    expect(
+      localGrowth,
+      `local ${localGrowth.toFixed(3)} vs field ${fieldGrowth.toFixed(3)}`,
+    ).toBeLessThan(fieldGrowth * 1.3);
 
     await page.mouse.up();
   });

--- a/e2e-tests/index.spec.ts
+++ b/e2e-tests/index.spec.ts
@@ -107,6 +107,24 @@ const litFraction = async (page: Page): Promise<number> => {
   return pixels.filter((sum) => sum > 24).length / pixels.length;
 };
 
+/** Mean brightness near a point. Both `point` and `radius` are fractions of the
+ * canvas, because callers hold viewport-relative positions, not sample indices. */
+const meanAround = (
+  pixels: number[],
+  point: { x: number; y: number },
+  radius: number,
+): number => {
+  const height = Math.round(pixels.length / SAMPLE_WIDTH);
+  const inside: number[] = [];
+  for (const [index, value] of pixels.entries()) {
+    const x = (index % SAMPLE_WIDTH) / SAMPLE_WIDTH;
+    const y = Math.floor(index / SAMPLE_WIDTH) / height;
+    if (Math.hypot(x - point.x, y - point.y) <= radius) inside.push(value);
+  }
+  if (inside.length === 0) return -1;
+  return inside.reduce((sum, value) => sum + value, 0) / inside.length;
+};
+
 /** Mean absolute brightness change between two samples, normalised to 0..1. */
 const meanChange = (before: number[], after: number[]): number => {
   if (before.length === 0 || before.length !== after.length) return -1;
@@ -395,6 +413,67 @@ test.describe("fluid canvas", () => {
     };
 
     expect(await changeBetweenFrames()).toBeGreaterThan(0.002);
+  });
+
+  test("stops painting when the browser revokes the pointer capture", async ({
+    page,
+  }) => {
+    // Raised because each canvas read is a screenshot, which costs seconds
+    // against CI's software renderer — the default 30s ceiling is not enough.
+    test.setTimeout(180_000);
+
+    await page.goto("/?seed=off");
+    await page.evaluate(() => {
+      window.localStorage.clear();
+    });
+    await page.goto("/?seed=off");
+    await expect(page.getByRole("alert")).toHaveCount(0);
+
+    await hideSettings(page);
+
+    const viewport = page.viewportSize() ?? { width: 1280, height: 720 };
+    const midY = viewport.height / 2;
+    // Abandoned mid-canvas, away from the edges, because the ring sampled around
+    // it has to stay on the canvas in every direction.
+    const abandoned = { x: 0.5, y: 0.5 };
+    await page.mouse.move(viewport.width * 0.3, midY);
+    await page.mouse.down();
+    await page.mouse.move(viewport.width * abandoned.x, midY, { steps: 6 });
+
+    // Dispatched by hand because Playwright's mouse cannot revoke a capture; the
+    // id must be its own 1, since PointerEvent's default 0 matches no stroke.
+    await page.evaluate(() => {
+      document.querySelector("canvas")?.dispatchEvent(
+        new PointerEvent("lostpointercapture", {
+          bubbles: true,
+          pointerId: 1,
+        }),
+      );
+    });
+
+    // Settled first because the dye already painted keeps advecting for a
+    // while, and that motion is not what this test is about.
+    /* eslint-disable playwright/no-wait-for-timeout */
+    await page.waitForTimeout(3000);
+    const before = await sampleCanvas(page);
+
+    await page.waitForTimeout(4000);
+    /* eslint-enable playwright/no-wait-for-timeout */
+    const after = await sampleCanvas(page);
+
+    // Compared against the field's own growth because dye keeps spreading
+    // either way — an absolute rise fires on both the fixed and broken builds.
+    const sum = (pixels: number[]): number =>
+      pixels.reduce((total, value) => total + value, 0) || 1;
+    const localGrowth =
+      meanAround(after, abandoned, 0.06) / meanAround(before, abandoned, 0.06);
+    const fieldGrowth = sum(after) / sum(before);
+
+    // A stranded stroke re-splats its last position every frame, so its dye
+    // piles up there faster than the field as a whole moves.
+    expect(localGrowth).toBeLessThan(fieldGrowth * 1.3);
+
+    await page.mouse.up();
   });
 
   test("paints the seed burst before any input", async ({ page }) => {

--- a/src/FluidCanvas.tsx
+++ b/src/FluidCanvas.tsx
@@ -119,6 +119,14 @@ export const FluidCanvas = () => {
     };
     const onPointerUp = (event: PointerEvent): void => {
       pointer.release(event.pointerId);
+      if (canvas.hasPointerCapture(event.pointerId)) {
+        canvas.releasePointerCapture(event.pointerId);
+      }
+    };
+    // Needed because a browser-revoked capture delivers no pointerup, which
+    // would strand the stroke active, splatting its last position every frame.
+    const onLostPointerCapture = (event: PointerEvent): void => {
+      pointer.release(event.pointerId);
     };
 
     const resizeCanvas = (): { width: number; height: number } => {
@@ -178,6 +186,7 @@ export const FluidCanvas = () => {
       canvas.addEventListener("pointermove", onPointerMove);
       canvas.addEventListener("pointerup", onPointerUp);
       canvas.addEventListener("pointercancel", onPointerUp);
+      canvas.addEventListener("lostpointercapture", onLostPointerCapture);
       observer.observe(canvas);
 
       let previous = performance.now();
@@ -236,6 +245,7 @@ export const FluidCanvas = () => {
       canvas.removeEventListener("pointermove", onPointerMove);
       canvas.removeEventListener("pointerup", onPointerUp);
       canvas.removeEventListener("pointercancel", onPointerUp);
+      canvas.removeEventListener("lostpointercapture", onLostPointerCapture);
       renderer?.destroy();
       rendererRef.current = null;
       pointerRef.current = null;


### PR DESCRIPTION
Closes #705.

## What changed

`FluidCanvas` took pointer capture on `pointerdown` with no matching release, and registered `pointerdown` / `pointermove` / `pointerup` / `pointercancel` only. A capture the browser revokes for its own reasons — a system gesture, the element being re-laid-out — delivers no `pointerup`, so the stroke stayed `active` and re-splatted its last position on every frame.

- Release the capture explicitly on `pointerup` / `pointercancel`.
- Treat `lostpointercapture` as a release, so a stroke cannot be stranded.

`PointerTracker` already drops a released stroke on the next `consume()`, so the fix is confined to the DOM listeners.

## Impact

User-visible: a revoked capture no longer leaves dye pumping into one spot until the next press. With a mouse the implicit release at `pointerup` already covered the common path, so there is no change to ordinary drags.

## On the explicit release

Review raised that the `hasPointerCapture` / `releasePointerCapture` block might be dead code, since the spec releases capture implicitly after `pointerup`. Measured in the real Chromium this suite runs, logging `hasPointerCapture` at handler entry:

| event | capture still held |
|---|---|
| `pointerup` | `false` — already released by the UA |
| `pointercancel` | `true` — **still held** |

So the block is load-bearing on the `pointercancel` path, and inert on the `pointerup` path. The `hasPointerCapture` guard is what keeps the latter from throwing `NotFoundError`.

## On the test

The obvious assertion — "brightness stops climbing" — does **not** work here, and the first version of this test passed on the broken build. Dye keeps advecting and spreading with or without the fix, so an absolute rise fires either way. Two things were needed:

- Compare growth **local to the abandoned point** against the field's own growth, rather than in absolute terms.
- Dispatch the synthetic `lostpointercapture` with `pointerId: 1`. `PointerEvent` defaults it to `0`, which matches no stroke — the release then silently does nothing and the test passes on both builds.

Review then found a second way it could pass without exercising anything: with no painted baseline, an unpainted drag makes `meanAround` return `-1` for both samples (`-1 / -1 = 1`), and `sum(...) || 1` forces `fieldGrowth` to 1 — every degenerate reading lands under the threshold. The pointer listeners attach only after `initGpu` resolves, so a press can genuinely precede them. Fixed by asserting a painted baseline before taking the ratio and dropping the `|| 1` fallback.

Measured ratio (local growth ÷ field growth) on the final test:

| build | ratio |
|---|---|
| broken | 1.51, 1.58, 1.64 |
| fixed | passes 3/3 |

The 1.3 threshold sits in the gap, and both ratios are now reported in the failure message so drift is visible rather than silent.

## Test plan

CI covers lint, all three typechecks, unit tests, and the Playwright suite. Beyond that:

- [x] Confirmed the test fails on the unfixed build and passes on the fixed one, re-measured after the review changes
- [x] Measured the `pointerup` / `pointercancel` capture-held split in the real browser
- [x] Full e2e suite green locally (13/13)
