### PR TITLE
feat: honour prefers-reduced-motion and pause the loop while hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ Real-time fluid simulation filling the browser viewport, solved entirely on the
 GPU with [WebGPU](https://www.w3.org/TR/webgpu/) compute shaders. It opens
 mid-motion and settles as the dye dissipates; drag anywhere to stir it. Under
 `prefers-reduced-motion` it opens still instead, and waits for a drag or a
-keypress before it animates. A panel
-behind the gear in the corner tunes the solver live — decay rates, splat size
-and force, pressure sweeps, and the grid resolutions — and remembers what you
-set.
+keypress before it animates. A panel behind the gear in the corner tunes the
+solver live — decay rates, splat size and force, pressure sweeps, and the grid
+resolutions — and remembers what you set.
 
 Built with React + Vite and deployed to
 [Cloudflare Workers](https://workers.cloudflare.com/) as static assets.
@@ -58,9 +57,9 @@ accumulating over a drag's frames, so it is injected brighter to compensate
 
 The solver advances by a fixed timestep while the frame loop accumulates real
 elapsed time, so the fluid behaves the same on a 60Hz and a 120Hz display. A
-gap longer than a frame or so — a hidden tab, a slept machine — is dropped
-rather than replayed, so returning to the tab resumes from the present instead
-of fast-forwarding through the gap. If the GPU device is lost, the
+gap longer than one frame's budget — a hidden tab, a slept machine — is capped
+at that budget rather than banked, so returning to the tab resumes from the
+present instead of fast-forwarding through the gap. If the GPU device is lost, the
 canvas is replaced by a notice instead of freezing in place.
 
 Two grids are in play: velocity and pressure run on a coarse grid, dye on a

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Real-time fluid simulation filling the browser viewport, solved entirely on the
 GPU with [WebGPU](https://www.w3.org/TR/webgpu/) compute shaders. It opens
-mid-motion and settles as the dye dissipates; drag anywhere to stir it. A panel
+mid-motion and settles as the dye dissipates; drag anywhere to stir it. Under
+`prefers-reduced-motion` it opens still instead, and waits for a drag or a
+keypress before it animates. A panel
 behind the gear in the corner tunes the solver live — decay rates, splat size
 and force, pressure sweeps, and the grid resolutions — and remembers what you
 set.
@@ -49,13 +51,16 @@ The dye field then advects along the projected velocity and a fullscreen
 triangle draws it.
 
 Splats come from two places: a drag, and a burst thrown in at startup so the
-first frame is already in motion. A seeded splat lands once rather than
+first frame is already in motion — the burst is skipped entirely under
+`prefers-reduced-motion`. A seeded splat lands once rather than
 accumulating over a drag's frames, so it is injected brighter to compensate
 (`SEED_DYE_GAIN`).
 
 The solver advances by a fixed timestep while the frame loop accumulates real
-elapsed time, so the fluid behaves the same on a 60Hz and a 120Hz display; a
-long stall is capped rather than replayed. If the GPU device is lost, the
+elapsed time, so the fluid behaves the same on a 60Hz and a 120Hz display. A
+gap longer than a frame or so — a hidden tab, a slept machine — is dropped
+rather than replayed, so returning to the tab resumes from the present instead
+of fast-forwarding through the gap. If the GPU device is lost, the
 canvas is replaced by a notice instead of freezing in place.
 
 Two grids are in play: velocity and pressure run on a coarse grid, dye on a

--- a/src/FluidCanvas.tsx
+++ b/src/FluidCanvas.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { MAX_STEPS_PER_FRAME, TIME_STEP } from "@/fluid/config";
 import { GpuUnavailableError, initGpu } from "@/fluid/gpu";
+import { MotionGate, prefersReducedMotion } from "@/fluid/motion";
 import { PointerTracker } from "@/fluid/pointer";
 import { createFluidRenderer } from "@/fluid/renderer";
 import type { ResolutionSettings } from "@/fluid/resolution";
@@ -95,6 +96,10 @@ export const FluidCanvas = () => {
     const pointer = new PointerTracker();
     pointer.setForce(settingsRef.current.splatForce);
     pointerRef.current = pointer;
+    const motion = new MotionGate(
+      prefersReducedMotion(window),
+      document.hidden,
+    );
     let renderer: FluidRenderer | null = null;
     let gpuDevice: GPUDevice | null = null;
     let frameId = 0;
@@ -110,6 +115,7 @@ export const FluidCanvas = () => {
 
     const onPointerDown = (event: PointerEvent): void => {
       const [x, y] = toNormalised(event);
+      motion.requestMotion();
       pointer.press(event.pointerId, x, y);
       canvas.setPointerCapture(event.pointerId);
     };
@@ -127,6 +133,10 @@ export const FluidCanvas = () => {
     // would strand the stroke active, splatting its last position every frame.
     const onLostPointerCapture = (event: PointerEvent): void => {
       pointer.release(event.pointerId);
+    };
+
+    const onVisibilityChange = (): void => {
+      motion.setHidden(document.hidden);
     };
 
     const resizeCanvas = (): { width: number; height: number } => {
@@ -187,19 +197,31 @@ export const FluidCanvas = () => {
       canvas.addEventListener("pointerup", onPointerUp);
       canvas.addEventListener("pointercancel", onPointerUp);
       canvas.addEventListener("lostpointercapture", onLostPointerCapture);
+      document.addEventListener("visibilitychange", onVisibilityChange);
       observer.observe(canvas);
 
       let previous = performance.now();
       let owed = 0;
       // Held until the first step runs: the loop may render before enough time
       // has accumulated for a step, and the burst has to land inside one.
-      let pending: Splat[] = seedEnabled(window.location.search)
-        ? seedSplats(Math.random)
-        : [];
+      let pending: Splat[] =
+        motion.seeds && seedEnabled(window.location.search)
+          ? seedSplats(Math.random)
+          : [];
 
       const loop = (now: number): void => {
-        owed += (now - previous) / 1000;
+        const elapsed = (now - previous) / 1000;
         previous = now;
+
+        if (!motion.open) {
+          // Dropped rather than banked, so reopening resumes from the present
+          // instead of fast-forwarding through however long the gate was shut.
+          owed = 0;
+          frameId = requestAnimationFrame(loop);
+          return;
+        }
+
+        owed += elapsed;
 
         const steps = Math.min(
           Math.floor(owed / TIME_STEP),
@@ -246,6 +268,7 @@ export const FluidCanvas = () => {
       canvas.removeEventListener("pointerup", onPointerUp);
       canvas.removeEventListener("pointercancel", onPointerUp);
       canvas.removeEventListener("lostpointercapture", onLostPointerCapture);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
       renderer?.destroy();
       rendererRef.current = null;
       pointerRef.current = null;

--- a/src/FluidCanvas.tsx
+++ b/src/FluidCanvas.tsx
@@ -2,7 +2,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { MAX_STEPS_PER_FRAME, TIME_STEP } from "@/fluid/config";
 import { GpuUnavailableError, initGpu } from "@/fluid/gpu";
-import { MotionGate, prefersReducedMotion } from "@/fluid/motion";
+import {
+  creditedElapsed,
+  MotionGate,
+  reducedMotionQuery,
+} from "@/fluid/motion";
 import { PointerTracker } from "@/fluid/pointer";
 import { createFluidRenderer } from "@/fluid/renderer";
 import type { ResolutionSettings } from "@/fluid/resolution";
@@ -96,8 +100,9 @@ export const FluidCanvas = () => {
     const pointer = new PointerTracker();
     pointer.setForce(settingsRef.current.splatForce);
     pointerRef.current = pointer;
+    const motionQuery = reducedMotionQuery(window);
     const motion = new MotionGate(
-      prefersReducedMotion(window),
+      motionQuery?.matches ?? false,
       document.hidden,
     );
     let renderer: FluidRenderer | null = null;
@@ -137,6 +142,18 @@ export const FluidCanvas = () => {
 
     const onVisibilityChange = (): void => {
       motion.setHidden(document.hidden);
+    };
+
+    const onMotionPreferenceChange = (): void => {
+      motion.setReducedMotion(motionQuery?.matches ?? false);
+    };
+
+    // Keyboard and assistive-technology users never fire pointerdown, so without
+    // this the reduced-motion hold would leave them a permanently blank canvas.
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      motion.requestMotion();
     };
 
     const resizeCanvas = (): { width: number; height: number } => {
@@ -197,7 +214,9 @@ export const FluidCanvas = () => {
       canvas.addEventListener("pointerup", onPointerUp);
       canvas.addEventListener("pointercancel", onPointerUp);
       canvas.addEventListener("lostpointercapture", onLostPointerCapture);
+      canvas.addEventListener("keydown", onKeyDown);
       document.addEventListener("visibilitychange", onVisibilityChange);
+      motionQuery?.addEventListener?.("change", onMotionPreferenceChange);
       observer.observe(canvas);
 
       let previous = performance.now();
@@ -214,14 +233,12 @@ export const FluidCanvas = () => {
         previous = now;
 
         if (!motion.open) {
-          // Dropped rather than banked, so reopening resumes from the present
-          // instead of fast-forwarding through however long the gate was shut.
           owed = 0;
           frameId = requestAnimationFrame(loop);
           return;
         }
 
-        owed += elapsed;
+        owed += creditedElapsed(elapsed);
 
         const steps = Math.min(
           Math.floor(owed / TIME_STEP),
@@ -268,7 +285,9 @@ export const FluidCanvas = () => {
       canvas.removeEventListener("pointerup", onPointerUp);
       canvas.removeEventListener("pointercancel", onPointerUp);
       canvas.removeEventListener("lostpointercapture", onLostPointerCapture);
+      canvas.removeEventListener("keydown", onKeyDown);
       document.removeEventListener("visibilitychange", onVisibilityChange);
+      motionQuery?.removeEventListener?.("change", onMotionPreferenceChange);
       renderer?.destroy();
       rendererRef.current = null;
       pointerRef.current = null;
@@ -292,7 +311,7 @@ export const FluidCanvas = () => {
 
   return (
     <>
-      <canvas ref={canvasRef} aria-label="Fluid simulation" />
+      <canvas ref={canvasRef} aria-label="Fluid simulation" tabIndex={0} />
       <SettingsPanel
         settings={settings}
         resolution={resolution}

--- a/src/fluid/motion.test.ts
+++ b/src/fluid/motion.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { MAX_STEPS_PER_FRAME, TIME_STEP } from "./config";
 import { creditedElapsed, MotionGate, reducedMotionQuery } from "./motion";
 
 const media = (matches: boolean) => vi.fn((_query: string) => ({ matches }));
@@ -24,21 +25,30 @@ describe("reducedMotionQuery", () => {
 });
 
 describe("creditedElapsed", () => {
+  const budget = MAX_STEPS_PER_FRAME * TIME_STEP;
+
   it("passes an ordinary frame through untouched", () => {
     expect(creditedElapsed(1 / 60)).toBeCloseTo(1 / 60, 6);
-    expect(creditedElapsed(1 / 15)).toBeCloseTo(1 / 15, 6);
+    expect(creditedElapsed(1 / 120)).toBeCloseTo(1 / 120, 6);
   });
 
-  it("drops a gap far longer than a frame instead of banking it", () => {
+  it("caps a gap at what one frame can drain, so none of it banks", () => {
     // The case the hidden-tab path produces: visibilitychange reopens the gate
     // before the first resumed frame, so this gap arrives with the gate open.
-    expect(creditedElapsed(60)).toBe(0);
-    expect(creditedElapsed(2)).toBe(0);
+    expect(creditedElapsed(60)).toBeCloseTo(budget, 6);
+    expect(creditedElapsed(2)).toBeCloseTo(budget, 6);
   });
 
-  it("credits time strictly below the cap and drops it strictly above", () => {
-    expect(creditedElapsed(0.25)).toBe(0.25);
-    expect(creditedElapsed(0.2501)).toBe(0);
+  it("still advances a slow frame rather than freezing the simulation", () => {
+    // A software renderer on CI exceeds the budget every frame; returning 0 here
+    // would stop the solver entirely and the dye would never decay.
+    expect(creditedElapsed(0.5)).toBeGreaterThan(0);
+    expect(creditedElapsed(0.1)).toBeGreaterThan(0);
+  });
+
+  it("credits a frame at the budget exactly, and never more", () => {
+    expect(creditedElapsed(budget)).toBeCloseTo(budget, 6);
+    expect(creditedElapsed(budget * 10)).toBeCloseTo(budget, 6);
   });
 });
 

--- a/src/fluid/motion.test.ts
+++ b/src/fluid/motion.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { MotionGate, prefersReducedMotion } from "./motion";
+
+const media = (matches: boolean) => vi.fn((_query: string) => ({ matches }));
+
+describe("prefersReducedMotion", () => {
+  it("reports the preference the browser answers with", () => {
+    expect(prefersReducedMotion({ matchMedia: media(true) })).toBe(true);
+    expect(prefersReducedMotion({ matchMedia: media(false) })).toBe(false);
+  });
+
+  it("asks for the reduce query, not some other motion query", () => {
+    const matchMedia = media(true);
+    prefersReducedMotion({ matchMedia });
+    expect(matchMedia).toHaveBeenCalledWith("(prefers-reduced-motion: reduce)");
+  });
+
+  it("treats a missing matchMedia as no preference", () => {
+    expect(prefersReducedMotion({})).toBe(false);
+  });
+});
+
+describe("MotionGate", () => {
+  it("runs and seeds when nothing asks it not to", () => {
+    const gate = new MotionGate(false, false);
+    expect(gate.open).toBe(true);
+    expect(gate.seeds).toBe(true);
+  });
+
+  it("opens still under the preference, and stays shut until asked", () => {
+    const gate = new MotionGate(true, false);
+    expect(gate.seeds).toBe(false);
+    expect(gate.open).toBe(false);
+
+    gate.requestMotion();
+    expect(gate.open).toBe(true);
+  });
+
+  it("closes while hidden and reopens on return", () => {
+    const gate = new MotionGate(false, false);
+    gate.setHidden(true);
+    expect(gate.open).toBe(false);
+    gate.setHidden(false);
+    expect(gate.open).toBe(true);
+  });
+
+  it("stays shut on a tab that starts hidden, without waiting for input", () => {
+    const gate = new MotionGate(false, true);
+    expect(gate.open).toBe(false);
+    // Distinguishes the two reasons: nothing but becoming visible opens this
+    // one, so a stray `requestMotion` must not.
+    gate.requestMotion();
+    expect(gate.open).toBe(false);
+    gate.setHidden(false);
+    expect(gate.open).toBe(true);
+  });
+
+  it("keeps the reduced-motion hold when a tab merely becomes visible", () => {
+    const gate = new MotionGate(true, true);
+    gate.setHidden(false);
+    expect(gate.open).toBe(false);
+    gate.requestMotion();
+    expect(gate.open).toBe(true);
+  });
+
+  it("re-closes on hide even after motion was requested", () => {
+    const gate = new MotionGate(true, false);
+    gate.requestMotion();
+    gate.setHidden(true);
+    expect(gate.open).toBe(false);
+    gate.setHidden(false);
+    expect(gate.open).toBe(true);
+  });
+});

--- a/src/fluid/motion.test.ts
+++ b/src/fluid/motion.test.ts
@@ -1,23 +1,44 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { MotionGate, prefersReducedMotion } from "./motion";
+import { creditedElapsed, MotionGate, reducedMotionQuery } from "./motion";
 
 const media = (matches: boolean) => vi.fn((_query: string) => ({ matches }));
 
-describe("prefersReducedMotion", () => {
-  it("reports the preference the browser answers with", () => {
-    expect(prefersReducedMotion({ matchMedia: media(true) })).toBe(true);
-    expect(prefersReducedMotion({ matchMedia: media(false) })).toBe(false);
+describe("reducedMotionQuery", () => {
+  it("hands back the query the browser answers with", () => {
+    expect(reducedMotionQuery({ matchMedia: media(true) })?.matches).toBe(true);
+    expect(reducedMotionQuery({ matchMedia: media(false) })?.matches).toBe(
+      false,
+    );
   });
 
   it("asks for the reduce query, not some other motion query", () => {
     const matchMedia = media(true);
-    prefersReducedMotion({ matchMedia });
+    reducedMotionQuery({ matchMedia });
     expect(matchMedia).toHaveBeenCalledWith("(prefers-reduced-motion: reduce)");
   });
 
-  it("treats a missing matchMedia as no preference", () => {
-    expect(prefersReducedMotion({})).toBe(false);
+  it("reports a missing matchMedia as no query to subscribe to", () => {
+    expect(reducedMotionQuery({})).toBeNull();
+  });
+});
+
+describe("creditedElapsed", () => {
+  it("passes an ordinary frame through untouched", () => {
+    expect(creditedElapsed(1 / 60)).toBeCloseTo(1 / 60, 6);
+    expect(creditedElapsed(1 / 15)).toBeCloseTo(1 / 15, 6);
+  });
+
+  it("drops a gap far longer than a frame instead of banking it", () => {
+    // The case the hidden-tab path produces: visibilitychange reopens the gate
+    // before the first resumed frame, so this gap arrives with the gate open.
+    expect(creditedElapsed(60)).toBe(0);
+    expect(creditedElapsed(2)).toBe(0);
+  });
+
+  it("credits time strictly below the cap and drops it strictly above", () => {
+    expect(creditedElapsed(0.25)).toBe(0.25);
+    expect(creditedElapsed(0.2501)).toBe(0);
   });
 });
 
@@ -62,6 +83,27 @@ describe("MotionGate", () => {
     expect(gate.open).toBe(false);
     gate.requestMotion();
     expect(gate.open).toBe(true);
+  });
+
+  it("re-arms the hold when the preference is switched on mid-session", () => {
+    const gate = new MotionGate(false, false);
+    expect(gate.open).toBe(true);
+
+    gate.setReducedMotion(true);
+    expect(gate.open).toBe(false);
+    expect(gate.seeds).toBe(false);
+
+    gate.requestMotion();
+    expect(gate.open).toBe(true);
+  });
+
+  it("releases a hold that was already lifted when the preference goes away", () => {
+    const gate = new MotionGate(true, false);
+    expect(gate.open).toBe(false);
+
+    gate.setReducedMotion(false);
+    expect(gate.open).toBe(true);
+    expect(gate.seeds).toBe(true);
   });
 
   it("re-closes on hide even after motion was requested", () => {

--- a/src/fluid/motion.ts
+++ b/src/fluid/motion.ts
@@ -1,3 +1,5 @@
+import { MAX_STEPS_PER_FRAME, TIME_STEP } from "./config";
+
 /** Narrower than `Window` so a caller without `matchMedia` — an older browser,
  * a bare test double — is a type the signature admits rather than a cast. */
 export interface MotionQuery {
@@ -13,14 +15,14 @@ export interface MotionQueryView {
 export const reducedMotionQuery = (view: MotionQueryView): MotionQuery | null =>
   view.matchMedia?.("(prefers-reduced-motion: reduce)") ?? null;
 
-/** Skipped rather than replayed, because `MAX_STEPS_PER_FRAME` caps only one
- * frame's catch-up and the excess drains later as fast-forward. */
-const MAX_FRAME_GAP_SECONDS = 0.25;
+/** Clamped, not dropped: a slow renderer legitimately exceeds the budget every
+ * frame, and discarding those gaps would stop the simulation advancing at all. */
+const MAX_FRAME_GAP_SECONDS = MAX_STEPS_PER_FRAME * TIME_STEP;
 
 /** Separate from the closed-gate branch because `visibilitychange` reopens the
  * gate before the first resumed frame, so that gap sees an open one. */
 export const creditedElapsed = (elapsed: number): number =>
-  elapsed > MAX_FRAME_GAP_SECONDS ? 0 : elapsed;
+  Math.min(elapsed, MAX_FRAME_GAP_SECONDS);
 
 export class MotionGate {
   private reducedMotion: boolean;

--- a/src/fluid/motion.ts
+++ b/src/fluid/motion.ts
@@ -1,22 +1,42 @@
 /** Narrower than `Window` so a caller without `matchMedia` — an older browser,
  * a bare test double — is a type the signature admits rather than a cast. */
-export interface MotionQueryView {
-  matchMedia?: (query: string) => { matches: boolean };
+export interface MotionQuery {
+  matches: boolean;
+  addEventListener?: (type: "change", listener: () => void) => void;
+  removeEventListener?: (type: "change", listener: () => void) => void;
 }
 
-export const prefersReducedMotion = (view: MotionQueryView): boolean =>
-  view.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+export interface MotionQueryView {
+  matchMedia?: (query: string) => MotionQuery;
+}
 
-/** `MAX_STEPS_PER_FRAME` bounds the catch-up replay after an idle gap but does
- * not prevent it, so time accumulated while closed must be discarded. */
+export const reducedMotionQuery = (view: MotionQueryView): MotionQuery | null =>
+  view.matchMedia?.("(prefers-reduced-motion: reduce)") ?? null;
+
+/** Skipped rather than replayed, because `MAX_STEPS_PER_FRAME` caps only one
+ * frame's catch-up and the excess drains later as fast-forward. */
+const MAX_FRAME_GAP_SECONDS = 0.25;
+
+/** Separate from the closed-gate branch because `visibilitychange` reopens the
+ * gate before the first resumed frame, so that gap sees an open one. */
+export const creditedElapsed = (elapsed: number): number =>
+  elapsed > MAX_FRAME_GAP_SECONDS ? 0 : elapsed;
+
 export class MotionGate {
-  private readonly reducedMotion: boolean;
+  private reducedMotion: boolean;
   private hidden: boolean;
   private awaitingInput: boolean;
 
   constructor(reducedMotion: boolean, hidden: boolean) {
     this.reducedMotion = reducedMotion;
     this.hidden = hidden;
+    this.awaitingInput = reducedMotion;
+  }
+
+  /** Enabling the preference mid-session re-arms the hold, so someone who turns
+   * it on because the motion is affecting them gets stillness without a reload. */
+  setReducedMotion(reducedMotion: boolean): void {
+    this.reducedMotion = reducedMotion;
     this.awaitingInput = reducedMotion;
   }
 

--- a/src/fluid/motion.ts
+++ b/src/fluid/motion.ts
@@ -1,0 +1,42 @@
+/** Narrower than `Window` so a caller without `matchMedia` — an older browser,
+ * a bare test double — is a type the signature admits rather than a cast. */
+export interface MotionQueryView {
+  matchMedia?: (query: string) => { matches: boolean };
+}
+
+export const prefersReducedMotion = (view: MotionQueryView): boolean =>
+  view.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+
+/** `MAX_STEPS_PER_FRAME` bounds the catch-up replay after an idle gap but does
+ * not prevent it, so time accumulated while closed must be discarded. */
+export class MotionGate {
+  private readonly reducedMotion: boolean;
+  private hidden: boolean;
+  private awaitingInput: boolean;
+
+  constructor(reducedMotion: boolean, hidden: boolean) {
+    this.reducedMotion = reducedMotion;
+    this.hidden = hidden;
+    this.awaitingInput = reducedMotion;
+  }
+
+  /** The opening burst is motion the user never asked for, so the preference
+   * suppresses it outright rather than damping it. */
+  get seeds(): boolean {
+    return !this.reducedMotion;
+  }
+
+  setHidden(hidden: boolean): void {
+    this.hidden = hidden;
+  }
+
+  /** Lifts the reduced-motion hold for the session. Visibility is deliberately
+   * unaffected: un-hiding a tab is not a request to animate. */
+  requestMotion(): void {
+    this.awaitingInput = false;
+  }
+
+  get open(): boolean {
+    return !this.hidden && !this.awaitingInput;
+  }
+}


### PR DESCRIPTION
Closes #711.

## What changed

The page is a full-viewport field that animates on load before any input, which
is the content class `prefers-reduced-motion` exists for. Under the preference
the opening burst is skipped and the loop holds still until the user asks for
motion. Separately, the loop no longer replays time that passed while it was
not running.

The decision lives in `src/fluid/motion.ts` (`MotionGate` + `creditedElapsed`)
rather than inline in the render loop, because the loop has no test harness of
its own and this is the part worth pinning.

## Why the gap handling is a clamp rather than a visibility guard

The first version gated on visibility alone: zero the accumulator whenever the
gate is shut. That does not work. Browsers throttle or suspend `requestAnimationFrame`
while a tab is hidden, and `visibilitychange` reopens the gate *before* the first
resumed frame — so that frame takes the open path and banks the entire hidden
span, which is exactly the case the guard was written for.

`creditedElapsed` caps each frame's credited time at `MAX_STEPS_PER_FRAME * TIME_STEP`
— what one frame can actually drain. That closes the visibility case and the ones
a visibility guard structurally cannot see: a slept machine, a frozen process, a
paused debugger. `MAX_STEPS_PER_FRAME` alone was not sufficient, because it caps a
single frame's catch-up but leaves the excess in the accumulator to drain over
later frames as fast-forward.

A cap rather than a discard, deliberately: an earlier revision here discarded any
gap over a fixed 0.25s, which stopped the solver outright on renderers slower than
that threshold. CI's software renderer is one, and the dye-decay e2e case caught
it. Capping keeps the no-banking property while letting a slow frame still advance.

## Accessibility

- The preference is subscribed (`change` on the `MediaQueryList`), not sampled
  once at mount — enabling it mid-session now takes effect without a reload, and
  re-arms the hold.
- `pointerdown` was the only path that lifted the hold, which left a keyboard or
  assistive-technology user under reduced motion with a permanently blank canvas.
  The canvas is now focusable and Enter/Space lift it too.

## Test plan

CI covers type-check, lint, unit and e2e. Beyond that:

- [x] Mutation-tested the new logic: removing the clamp fails 2 tests, and
      reverting to the discard that broke CI fails 3 — so that regression cannot
      reach CI again. Each `MotionGate` branch fails its own tests when inverted.
- [x] Confirmed the seed-burst e2e still passes on a default browser, so the
      reduced-motion gate does not regress the unaffected path.
- [x] Re-ran the dye-decay case that caught the discard bug; it passes.
- [x] `e2e-tests/index.spec.ts:418` ("stops painting when the browser revokes the
      pointer capture") is flaky locally on a tolerance boundary. Verified
      pre-existing and unrelated to this branch: at the merge-base `fe8370a` it
      flakes 2 of 3 runs, versus 1 of 3 here. Worth a separate look.

Whether rAF is fully suspended or merely throttled while hidden could not be
measured — headless Chromium would not report `document.hidden` across three
approaches. The fix holds either way, which is why it does not depend on the
answer.
