### PR TITLE
Split renderer.ts into its four concerns, with shader-derived uniform coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ without that the notice would be a dead end.
 ## Project layout
 
 - `src/fluid/` — the simulation: WGSL shaders, the WebGPU pipeline setup
-  (`renderer.ts`), device acquisition (`gpu.ts`), and pointer tracking
+  (`pipelines.ts`), the per-resolution resources (`resources.ts`), the frame
+  encoder (`frame.ts`), device acquisition (`gpu.ts`), and pointer tracking
 - `src/FluidCanvas.tsx` — the canvas host; owns the animation loop, and holds
   the settings the panel edits alongside any failure to report
 - `src/SettingsPanel.tsx` — the collapsible panel of solver controls

--- a/src/fluid/frame.ts
+++ b/src/fluid/frame.ts
@@ -1,0 +1,117 @@
+import { dispatchSize } from "./grid";
+import type { Pipelines } from "./pipelines";
+import type { Resources } from "./resources";
+
+export interface FrameEncode {
+  device: GPUDevice;
+  context: GPUCanvasContext;
+  pipelines: Pipelines;
+  resources: Resources;
+  sharedBindGroup: GPUBindGroup;
+  splatUniformBindGroup: GPUBindGroup;
+  splatCount: number;
+  splatSlotBytes: number;
+  pressureIterations: number;
+}
+
+export const encodeFrame = ({
+  device,
+  context,
+  pipelines,
+  resources,
+  sharedBindGroup,
+  splatUniformBindGroup,
+  splatCount,
+  splatSlotBytes,
+  pressureIterations,
+}: FrameEncode): void => {
+  const { simGrid, dyeGrid, velocity, dye, pressure } = resources;
+
+  const encoder = device.createCommandEncoder();
+  const pass = encoder.beginComputePass();
+  pass.setBindGroup(0, sharedBindGroup);
+
+  const simDispatch = dispatchSize(simGrid);
+  const dyeDispatch = dispatchSize(dyeGrid);
+
+  const run = (
+    pipeline: GPUComputePipeline,
+    group: GPUBindGroup,
+    [x, y]: readonly [number, number],
+  ): void => {
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(1, group);
+    pass.dispatchWorkgroups(x, y);
+  };
+
+  run(
+    pipelines.advect,
+    resources.advectVelocity[velocity.readFace],
+    simDispatch,
+  );
+  velocity.swap();
+
+  // Every splat is a full pass over both grids, so the frame's cost grows with
+  // their count — the seed burst is deliberately a one-off.
+  for (let index = 0; index < splatCount; index++) {
+    pass.setBindGroup(2, splatUniformBindGroup, [index * splatSlotBytes]);
+
+    run(
+      pipelines.splat,
+      resources.splatVelocity[velocity.readFace],
+      simDispatch,
+    );
+    velocity.swap();
+
+    run(pipelines.splat, resources.splatDye[dye.readFace], dyeDispatch);
+    dye.swap();
+  }
+
+  run(
+    pipelines.divergence,
+    resources.divergencePass[velocity.readFace],
+    simDispatch,
+  );
+
+  for (let i = 0; i < pressureIterations; i++) {
+    run(
+      pipelines.pressure,
+      resources.pressurePass[pressure.readFace],
+      simDispatch,
+    );
+    pressure.swap();
+  }
+
+  run(
+    pipelines.gradientSubtract,
+    resources.gradientPass[pressure.readFace][velocity.readFace],
+    simDispatch,
+  );
+  velocity.swap();
+
+  run(
+    pipelines.advect,
+    resources.advectDye[velocity.readFace][dye.readFace],
+    dyeDispatch,
+  );
+  dye.swap();
+
+  pass.end();
+
+  const display = encoder.beginRenderPass({
+    colorAttachments: [
+      {
+        view: context.getCurrentTexture().createView(),
+        loadOp: "clear",
+        storeOp: "store",
+        clearValue: { r: 0, g: 0, b: 0, a: 1 },
+      },
+    ],
+  });
+  display.setPipeline(pipelines.display);
+  display.setBindGroup(0, resources.display[dye.readFace]);
+  display.draw(3);
+  display.end();
+
+  device.queue.submit([encoder.finish()]);
+};

--- a/src/fluid/pipelines.ts
+++ b/src/fluid/pipelines.ts
@@ -1,0 +1,164 @@
+import { WORKGROUP_SIZE } from "./config";
+import renderShaderSource from "./render.wgsl?raw";
+import simulationShaderSource from "./simulation.wgsl?raw";
+import { SPLAT_UNIFORM_BYTES } from "./uniforms";
+
+// 32-bit float: WebGPU guarantees write-only storage access for these, while
+// the 16-bit forms need an optional feature.
+export const VELOCITY_FORMAT: GPUTextureFormat = "rgba32float";
+export const DYE_FORMAT: GPUTextureFormat = "rgba32float";
+export const PRESSURE_FORMAT: GPUTextureFormat = "r32float";
+
+/** Layouts ride along because a bind group must be built against the same
+ * layout object its pipeline was — an identical-shape copy is a different one. */
+export interface Pipelines {
+  simulationModule: GPUShaderModule;
+  sharedLayout: GPUBindGroupLayout;
+  splatUniformLayout: GPUBindGroupLayout;
+  advectLayout: GPUBindGroupLayout;
+  divergenceLayout: GPUBindGroupLayout;
+  pressureLayout: GPUBindGroupLayout;
+  gradientLayout: GPUBindGroupLayout;
+  splatLayout: GPUBindGroupLayout;
+  renderLayout: GPUBindGroupLayout;
+  advect: GPUComputePipeline;
+  divergence: GPUComputePipeline;
+  pressure: GPUComputePipeline;
+  gradientSubtract: GPUComputePipeline;
+  splat: GPUComputePipeline;
+  display: GPURenderPipeline;
+}
+
+export const createPipelines = (
+  device: GPUDevice,
+  canvasFormat: GPUTextureFormat,
+): Pipelines => {
+  // Substituted rather than duplicated: the host's dispatch count and the
+  // shader's workgroup size must agree, and a drift under-simulates in silence.
+  const simulationModule = device.createShaderModule({
+    code: simulationShaderSource.replaceAll(
+      "WORKGROUP_SIZE",
+      String(WORKGROUP_SIZE),
+    ),
+    label: "fluid-simulation",
+  });
+  const renderModule = device.createShaderModule({
+    code: renderShaderSource,
+    label: "fluid-render",
+  });
+
+  const sharedLayout = device.createBindGroupLayout({
+    entries: [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: "uniform" },
+      },
+    ],
+  });
+
+  const splatUniformLayout = device.createBindGroupLayout({
+    entries: [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: {
+          type: "uniform",
+          hasDynamicOffset: true,
+          minBindingSize: SPLAT_UNIFORM_BYTES,
+        },
+      },
+    ],
+  });
+
+  const texture = (binding: number): GPUBindGroupLayoutEntry => ({
+    binding,
+    visibility: GPUShaderStage.COMPUTE,
+    texture: { sampleType: "unfilterable-float" },
+  });
+  const storage = (
+    binding: number,
+    format: GPUTextureFormat,
+  ): GPUBindGroupLayoutEntry => ({
+    binding,
+    visibility: GPUShaderStage.COMPUTE,
+    storageTexture: { access: "write-only", format },
+  });
+  const uniform = (binding: number): GPUBindGroupLayoutEntry => ({
+    binding,
+    visibility: GPUShaderStage.COMPUTE,
+    buffer: { type: "uniform" },
+  });
+
+  const advectLayout = device.createBindGroupLayout({
+    entries: [texture(0), texture(1), storage(2, VELOCITY_FORMAT), uniform(3)],
+  });
+  const divergenceLayout = device.createBindGroupLayout({
+    entries: [texture(0), storage(1, PRESSURE_FORMAT)],
+  });
+  const pressureLayout = device.createBindGroupLayout({
+    entries: [texture(0), texture(1), storage(2, PRESSURE_FORMAT)],
+  });
+  const gradientLayout = device.createBindGroupLayout({
+    entries: [texture(0), texture(1), storage(2, VELOCITY_FORMAT)],
+  });
+  const splatLayout = device.createBindGroupLayout({
+    entries: [texture(0), storage(1, VELOCITY_FORMAT), uniform(2)],
+  });
+
+  const computePipeline = (
+    entryPoint: string,
+    passLayout: GPUBindGroupLayout,
+    splatUniforms?: GPUBindGroupLayout,
+  ): GPUComputePipeline =>
+    device.createComputePipeline({
+      label: entryPoint,
+      layout: device.createPipelineLayout({
+        bindGroupLayouts:
+          splatUniforms === undefined
+            ? [sharedLayout, passLayout]
+            : [sharedLayout, passLayout, splatUniforms],
+      }),
+      compute: { module: simulationModule, entryPoint },
+    });
+
+  const renderLayout = device.createBindGroupLayout({
+    entries: [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.FRAGMENT,
+        texture: { sampleType: "unfilterable-float" },
+      },
+    ],
+  });
+
+  const display = device.createRenderPipeline({
+    label: "fluid-display",
+    layout: device.createPipelineLayout({ bindGroupLayouts: [renderLayout] }),
+    vertex: { module: renderModule, entryPoint: "vertexMain" },
+    fragment: {
+      module: renderModule,
+      entryPoint: "fragmentMain",
+      targets: [{ format: canvasFormat }],
+    },
+    primitive: { topology: "triangle-list" },
+  });
+
+  return {
+    simulationModule,
+    sharedLayout,
+    splatUniformLayout,
+    advectLayout,
+    divergenceLayout,
+    pressureLayout,
+    gradientLayout,
+    splatLayout,
+    renderLayout,
+    advect: computePipeline("advect", advectLayout),
+    divergence: computePipeline("divergence", divergenceLayout),
+    pressure: computePipeline("pressure", pressureLayout),
+    gradientSubtract: computePipeline("gradientSubtract", gradientLayout),
+    splat: computePipeline("splat", splatLayout, splatUniformLayout),
+    display,
+  };
+};

--- a/src/fluid/renderer.ts
+++ b/src/fluid/renderer.ts
@@ -1,58 +1,27 @@
-import { MAX_SPLATS_PER_FRAME, TIME_STEP, WORKGROUP_SIZE } from "./config";
-import { DoubleBuffer } from "./doubleBuffer";
+import { MAX_SPLATS_PER_FRAME, TIME_STEP } from "./config";
+import type { DoubleBuffer } from "./doubleBuffer";
+import { encodeFrame } from "./frame";
 import type { Grid } from "./grid";
-import { dispatchSize, fitGrids, needsRebuild } from "./grid";
-import type { ProjectionScale } from "./projection";
-import { projectionScale, projectionUniform } from "./projection";
-import renderShaderSource from "./render.wgsl?raw";
+import { fitGrids, needsRebuild } from "./grid";
+import { createPipelines } from "./pipelines";
 import type { ResampleField } from "./resample";
 import { createFieldResampler } from "./resample";
 import type { ResolutionSettings } from "./resolution";
 import { sameResolution } from "./resolution";
+import type { Resources } from "./resources";
+import { buildResources, releaseResources } from "./resources";
 import type { FluidSettings } from "./settings";
 import { DEFAULT_SETTINGS } from "./settings";
-import simulationShaderSource from "./simulation.wgsl?raw";
 import type { FluidRenderer, Splat } from "./types";
-
-/** Float index of each `Uniforms` member in `simulation.wgsl`. */
-const UNIFORM = {
-  simSize: 0,
-  dt: 2,
-  aspect: 3,
-  toCells: 4,
-  toStored: 6,
-} as const;
-
-const UNIFORM_FLOATS = 8;
-const UNIFORM_BYTES = UNIFORM_FLOATS * 4;
-
-/** Float index of each `SplatUniforms` member in `simulation.wgsl` — WGSL
- * aligns the `vec4f` to 16 bytes, leaving a hole a positional array would
- * misfill. */
-const SPLAT_UNIFORM = {
-  point: 0,
-  delta: 2,
-  color: 4,
-  radius: 8,
-} as const;
-
-const SPLAT_UNIFORM_FLOATS = 12;
-
-const ADVECT_PARAM = {
-  gridSize: 0,
-  dissipation: 2,
-} as const;
-
-const PARAM_BYTES = 16;
-
-// 32-bit float: WebGPU guarantees write-only storage access for these, while
-// the 16-bit forms need an optional feature.
-const VELOCITY_FORMAT: GPUTextureFormat = "rgba32float";
-const DYE_FORMAT: GPUTextureFormat = "rgba32float";
-const PRESSURE_FORMAT: GPUTextureFormat = "r32float";
-
-const STORAGE_USAGE =
-  GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING;
+import {
+  ADVECT_PARAM,
+  packSplatUniforms,
+  packUniforms,
+  SPLAT_UNIFORM_BYTES,
+  SPLAT_UNIFORM_FLOATS,
+  UNIFORM_BYTES,
+  UNIFORM_FLOATS,
+} from "./uniforms";
 
 export const createFluidRenderer = (
   device: GPUDevice,
@@ -62,19 +31,7 @@ export const createFluidRenderer = (
   height: number,
   initialResolution: ResolutionSettings,
 ): FluidRenderer => {
-  // Substituted rather than duplicated: the host's dispatch count and the
-  // shader's workgroup size must agree, and a drift under-simulates in silence.
-  const simulationModule = device.createShaderModule({
-    code: simulationShaderSource.replaceAll(
-      "WORKGROUP_SIZE",
-      String(WORKGROUP_SIZE),
-    ),
-    label: "fluid-simulation",
-  });
-  const renderModule = device.createShaderModule({
-    code: renderShaderSource,
-    label: "fluid-render",
-  });
+  const pipelines = createPipelines(device, canvasFormat);
 
   const uniformBuffer = device.createBuffer({
     size: UNIFORM_BYTES,
@@ -86,358 +43,38 @@ export const createFluidRenderer = (
   // struct size would otherwise get offsets that are not multiples of it.
   const splatAlignment = device.limits.minUniformBufferOffsetAlignment;
   const splatSlotBytes =
-    Math.ceil((SPLAT_UNIFORM_FLOATS * 4) / splatAlignment) * splatAlignment;
+    Math.ceil(SPLAT_UNIFORM_BYTES / splatAlignment) * splatAlignment;
   const splatBuffer = device.createBuffer({
     size: splatSlotBytes * MAX_SPLATS_PER_FRAME,
     usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
   });
   const splatData = new Float32Array(SPLAT_UNIFORM_FLOATS);
 
-  const sharedLayout = device.createBindGroupLayout({
-    entries: [
-      {
-        binding: 0,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: "uniform" },
-      },
-    ],
-  });
-
   const sharedBindGroup = device.createBindGroup({
-    layout: sharedLayout,
+    layout: pipelines.sharedLayout,
     entries: [{ binding: 0, resource: { buffer: uniformBuffer } }],
   });
 
-  const splatUniformLayout = device.createBindGroupLayout({
-    entries: [
-      {
-        binding: 0,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: {
-          type: "uniform",
-          hasDynamicOffset: true,
-          minBindingSize: SPLAT_UNIFORM_FLOATS * 4,
-        },
-      },
-    ],
-  });
-
   const splatUniformBindGroup = device.createBindGroup({
-    layout: splatUniformLayout,
+    layout: pipelines.splatUniformLayout,
     entries: [
       {
         binding: 0,
-        resource: { buffer: splatBuffer, size: SPLAT_UNIFORM_FLOATS * 4 },
+        resource: { buffer: splatBuffer, size: SPLAT_UNIFORM_BYTES },
       },
     ],
   });
-
-  const texture = (binding: number): GPUBindGroupLayoutEntry => ({
-    binding,
-    visibility: GPUShaderStage.COMPUTE,
-    texture: { sampleType: "unfilterable-float" },
-  });
-  const storage = (
-    binding: number,
-    format: GPUTextureFormat,
-  ): GPUBindGroupLayoutEntry => ({
-    binding,
-    visibility: GPUShaderStage.COMPUTE,
-    storageTexture: { access: "write-only", format },
-  });
-  const uniform = (binding: number): GPUBindGroupLayoutEntry => ({
-    binding,
-    visibility: GPUShaderStage.COMPUTE,
-    buffer: { type: "uniform" },
-  });
-
-  const advectLayout = device.createBindGroupLayout({
-    entries: [texture(0), texture(1), storage(2, VELOCITY_FORMAT), uniform(3)],
-  });
-  const divergenceLayout = device.createBindGroupLayout({
-    entries: [texture(0), storage(1, PRESSURE_FORMAT)],
-  });
-  const pressureLayout = device.createBindGroupLayout({
-    entries: [texture(0), texture(1), storage(2, PRESSURE_FORMAT)],
-  });
-  const gradientLayout = device.createBindGroupLayout({
-    entries: [texture(0), texture(1), storage(2, VELOCITY_FORMAT)],
-  });
-  const splatLayout = device.createBindGroupLayout({
-    entries: [texture(0), storage(1, VELOCITY_FORMAT), uniform(2)],
-  });
-
-  const computePipeline = (
-    entryPoint: string,
-    passLayout: GPUBindGroupLayout,
-    splatUniforms?: GPUBindGroupLayout,
-  ): GPUComputePipeline =>
-    device.createComputePipeline({
-      label: entryPoint,
-      layout: device.createPipelineLayout({
-        bindGroupLayouts:
-          splatUniforms === undefined
-            ? [sharedLayout, passLayout]
-            : [sharedLayout, passLayout, splatUniforms],
-      }),
-      compute: { module: simulationModule, entryPoint },
-    });
-
-  const pipelines = {
-    advect: computePipeline("advect", advectLayout),
-    divergence: computePipeline("divergence", divergenceLayout),
-    pressure: computePipeline("pressure", pressureLayout),
-    gradientSubtract: computePipeline("gradientSubtract", gradientLayout),
-    splat: computePipeline("splat", splatLayout, splatUniformLayout),
-  };
-
-  const renderLayout = device.createBindGroupLayout({
-    entries: [
-      {
-        binding: 0,
-        visibility: GPUShaderStage.FRAGMENT,
-        texture: { sampleType: "unfilterable-float" },
-      },
-    ],
-  });
-
-  const renderPipeline = device.createRenderPipeline({
-    label: "fluid-display",
-    layout: device.createPipelineLayout({ bindGroupLayouts: [renderLayout] }),
-    vertex: { module: renderModule, entryPoint: "vertexMain" },
-    fragment: {
-      module: renderModule,
-      entryPoint: "fragmentMain",
-      targets: [{ format: canvasFormat }],
-    },
-    primitive: { topology: "triangle-list" },
-  });
-
-  const makeParamBuffer = (values: readonly number[]): GPUBuffer => {
-    const buffer = device.createBuffer({
-      size: PARAM_BYTES,
-      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-    });
-    const data = new Float32Array(PARAM_BYTES / 4);
-    data.set(values);
-    device.queue.writeBuffer(buffer, 0, data);
-    return buffer;
-  };
-
-  const makeAdvectParams = (grid: Grid, dissipation: number): GPUBuffer => {
-    const values = new Array<number>(PARAM_BYTES / 4).fill(0);
-    values[ADVECT_PARAM.gridSize] = grid.width;
-    values[ADVECT_PARAM.gridSize + 1] = grid.height;
-    values[ADVECT_PARAM.dissipation] = dissipation;
-    return makeParamBuffer(values);
-  };
-
-  /** One bind group per face the source buffer may be on, indexed by that
-   * face — the pressure solve alone would otherwise build one per sweep. */
-  type FacePair = readonly [GPUBindGroup, GPUBindGroup];
-
-  interface Resources {
-    simGrid: Grid;
-    dyeGrid: Grid;
-    scale: ProjectionScale;
-    velocity: DoubleBuffer;
-    dye: DoubleBuffer;
-    pressure: DoubleBuffer;
-    divergence: GPUTexture;
-    ownedParamBuffers: readonly GPUBuffer[];
-    advectVelocityParams: GPUBuffer;
-    advectDyeParams: GPUBuffer;
-    advectVelocity: FacePair;
-    /** Indexed by velocity face, then dye face: dye advection reads both. */
-    advectDye: readonly [FacePair, FacePair];
-    splatVelocity: FacePair;
-    splatDye: FacePair;
-    divergencePass: FacePair;
-    pressurePass: FacePair;
-    /** Indexed by pressure face, then velocity face. */
-    gradientPass: readonly [FacePair, FacePair];
-    display: FacePair;
-  }
 
   const resampler = createFieldResampler(
     device,
-    simulationModule,
-    sharedLayout,
+    pipelines.simulationModule,
+    pipelines.sharedLayout,
   );
 
   let resources: Resources | null = null;
   let settings: FluidSettings = DEFAULT_SETTINGS;
   let resolution: ResolutionSettings = initialResolution;
   let canvasSize = { width, height };
-
-  const buildResources = (
-    canvasWidth: number,
-    canvasHeight: number,
-  ): Resources => {
-    const { simGrid, dyeGrid } = fitGrids(
-      canvasWidth,
-      canvasHeight,
-      resolution,
-    );
-    const scale = projectionScale(simGrid.width, simGrid.height);
-
-    const velocity = new DoubleBuffer(device, simGrid, VELOCITY_FORMAT);
-    const dye = new DoubleBuffer(device, dyeGrid, DYE_FORMAT);
-    const pressure = new DoubleBuffer(device, simGrid, PRESSURE_FORMAT);
-
-    const divergence = device.createTexture({
-      size: [simGrid.width, simGrid.height],
-      format: PRESSURE_FORMAT,
-      usage: STORAGE_USAGE,
-    });
-    const divergenceView = divergence.createView();
-
-    const advectVelocityParams = makeAdvectParams(
-      simGrid,
-      settings.velocityDissipation,
-    );
-    const advectDyeParams = makeAdvectParams(dyeGrid, settings.dyeDissipation);
-    const splatVelocityParams = makeParamBuffer([
-      simGrid.width,
-      simGrid.height,
-      1,
-      0,
-    ]);
-    const splatDyeParams = makeParamBuffer([
-      dyeGrid.width,
-      dyeGrid.height,
-      0,
-      0,
-    ]);
-
-    const bindGroup = (
-      layout: GPUBindGroupLayout,
-      entries: GPUBindGroupEntry[],
-    ): GPUBindGroup => device.createBindGroup({ layout, entries });
-
-    /** Build one bind group per face of `source`, given how to bind that face. */
-    const perFace = (
-      source: DoubleBuffer,
-      build: (read: GPUTextureView, write: GPUTextureView) => GPUBindGroup,
-    ): FacePair => [
-      build(source.views[0], source.views[1]),
-      build(source.views[1], source.views[0]),
-    ];
-
-    const advectVelocity = perFace(velocity, (read, write) =>
-      bindGroup(advectLayout, [
-        { binding: 0, resource: read },
-        { binding: 1, resource: read },
-        { binding: 2, resource: write },
-        { binding: 3, resource: { buffer: advectVelocityParams } },
-      ]),
-    );
-
-    const advectDye: readonly [FacePair, FacePair] = [
-      perFace(dye, (read, write) =>
-        bindGroup(advectLayout, [
-          { binding: 0, resource: read },
-          { binding: 1, resource: velocity.views[0] },
-          { binding: 2, resource: write },
-          { binding: 3, resource: { buffer: advectDyeParams } },
-        ]),
-      ),
-      perFace(dye, (read, write) =>
-        bindGroup(advectLayout, [
-          { binding: 0, resource: read },
-          { binding: 1, resource: velocity.views[1] },
-          { binding: 2, resource: write },
-          { binding: 3, resource: { buffer: advectDyeParams } },
-        ]),
-      ),
-    ];
-
-    const splatVelocity = perFace(velocity, (read, write) =>
-      bindGroup(splatLayout, [
-        { binding: 0, resource: read },
-        { binding: 1, resource: write },
-        { binding: 2, resource: { buffer: splatVelocityParams } },
-      ]),
-    );
-
-    const splatDye = perFace(dye, (read, write) =>
-      bindGroup(splatLayout, [
-        { binding: 0, resource: read },
-        { binding: 1, resource: write },
-        { binding: 2, resource: { buffer: splatDyeParams } },
-      ]),
-    );
-
-    const divergencePass = perFace(velocity, (read) =>
-      bindGroup(divergenceLayout, [
-        { binding: 0, resource: read },
-        { binding: 1, resource: divergenceView },
-      ]),
-    );
-
-    const pressurePass = perFace(pressure, (read, write) =>
-      bindGroup(pressureLayout, [
-        { binding: 0, resource: read },
-        { binding: 1, resource: divergenceView },
-        { binding: 2, resource: write },
-      ]),
-    );
-
-    const gradientPass: readonly [FacePair, FacePair] = [
-      perFace(velocity, (read, write) =>
-        bindGroup(gradientLayout, [
-          { binding: 0, resource: pressure.views[0] },
-          { binding: 1, resource: read },
-          { binding: 2, resource: write },
-        ]),
-      ),
-      perFace(velocity, (read, write) =>
-        bindGroup(gradientLayout, [
-          { binding: 0, resource: pressure.views[1] },
-          { binding: 1, resource: read },
-          { binding: 2, resource: write },
-        ]),
-      ),
-    ];
-
-    const display = perFace(dye, (read) =>
-      bindGroup(renderLayout, [{ binding: 0, resource: read }]),
-    );
-
-    return {
-      simGrid,
-      dyeGrid,
-      scale,
-      velocity,
-      dye,
-      pressure,
-      divergence,
-      ownedParamBuffers: [
-        advectVelocityParams,
-        advectDyeParams,
-        splatVelocityParams,
-        splatDyeParams,
-      ],
-      advectVelocityParams,
-      advectDyeParams,
-      advectVelocity,
-      advectDye,
-      splatVelocity,
-      splatDye,
-      divergencePass,
-      pressurePass,
-      gradientPass,
-      display,
-    };
-  };
-
-  const releaseResources = (current: Resources): void => {
-    current.velocity.destroy();
-    current.dye.destroy();
-    current.pressure.destroy();
-    current.divergence.destroy();
-    for (const buffer of current.ownedParamBuffers) buffer.destroy();
-  };
 
   const liveFace = (buffer: DoubleBuffer, grid: Grid): ResampleField => ({
     view: buffer.views[buffer.readFace],
@@ -469,7 +106,12 @@ export const createFluidRenderer = (
    * grids; the two sets overlap for one submit, doubling texture memory. */
   const rebuild = (canvasWidth: number, canvasHeight: number): void => {
     const previous = resources;
-    const next = buildResources(canvasWidth, canvasHeight);
+    const next = buildResources(
+      device,
+      pipelines,
+      fitGrids(canvasWidth, canvasHeight, resolution),
+      settings,
+    );
     if (previous !== null) {
       carryFields(previous, next);
       releaseResources(previous);
@@ -516,23 +158,18 @@ export const createFluidRenderer = (
     const current = resources;
     if (current === null) return;
 
-    const { simGrid, dyeGrid, scale, velocity, dye, pressure } = current;
-
-    uniformData.set([simGrid.width, simGrid.height], UNIFORM.simSize);
-    uniformData[UNIFORM.dt] = TIME_STEP;
-    uniformData[UNIFORM.aspect] = dyeGrid.width / dyeGrid.height;
-    const metric = projectionUniform(scale);
-    uniformData.set(metric.toCells, UNIFORM.toCells);
-    uniformData.set(metric.toStored, UNIFORM.toStored);
-
+    packUniforms(
+      uniformData,
+      current.simGrid,
+      current.dyeGrid,
+      current.scale,
+      TIME_STEP,
+    );
     device.queue.writeBuffer(uniformBuffer, 0, uniformData);
 
     const applied = splats.slice(0, MAX_SPLATS_PER_FRAME);
     applied.forEach((splat, index) => {
-      splatData.set([splat.x, splat.y], SPLAT_UNIFORM.point);
-      splatData.set([splat.dx, splat.dy], SPLAT_UNIFORM.delta);
-      splatData.set(splat.color, SPLAT_UNIFORM.color);
-      splatData[SPLAT_UNIFORM.radius] = settings.splatRadius;
+      packSplatUniforms(splatData, splat, settings.splatRadius);
       device.queue.writeBuffer(
         splatBuffer,
         index * splatSlotBytes,
@@ -542,96 +179,17 @@ export const createFluidRenderer = (
       );
     });
 
-    const encoder = device.createCommandEncoder();
-    const pass = encoder.beginComputePass();
-    pass.setBindGroup(0, sharedBindGroup);
-
-    const simDispatch = dispatchSize(simGrid);
-    const dyeDispatch = dispatchSize(dyeGrid);
-
-    const run = (
-      pipeline: GPUComputePipeline,
-      group: GPUBindGroup,
-      [x, y]: readonly [number, number],
-    ): void => {
-      pass.setPipeline(pipeline);
-      pass.setBindGroup(1, group);
-      pass.dispatchWorkgroups(x, y);
-    };
-
-    // 1. Advect velocity through itself.
-    run(
-      pipelines.advect,
-      current.advectVelocity[velocity.readFace],
-      simDispatch,
-    );
-    velocity.swap();
-
-    // 2. Inject each splat's force and colour. Every splat is a full pass over
-    // both grids, so the frame's cost grows with their count — the seed burst
-    // is deliberately a one-off.
-    applied.forEach((_, index) => {
-      pass.setBindGroup(2, splatUniformBindGroup, [index * splatSlotBytes]);
-
-      run(
-        pipelines.splat,
-        current.splatVelocity[velocity.readFace],
-        simDispatch,
-      );
-      velocity.swap();
-
-      run(pipelines.splat, current.splatDye[dye.readFace], dyeDispatch);
-      dye.swap();
+    encodeFrame({
+      device,
+      context,
+      pipelines,
+      resources: current,
+      sharedBindGroup,
+      splatUniformBindGroup,
+      splatCount: applied.length,
+      splatSlotBytes,
+      pressureIterations: settings.pressureIterations,
     });
-
-    // 3. Project: make the velocity field divergence-free.
-    run(
-      pipelines.divergence,
-      current.divergencePass[velocity.readFace],
-      simDispatch,
-    );
-
-    for (let i = 0; i < settings.pressureIterations; i++) {
-      run(
-        pipelines.pressure,
-        current.pressurePass[pressure.readFace],
-        simDispatch,
-      );
-      pressure.swap();
-    }
-
-    run(
-      pipelines.gradientSubtract,
-      current.gradientPass[pressure.readFace][velocity.readFace],
-      simDispatch,
-    );
-    velocity.swap();
-
-    run(
-      pipelines.advect,
-      current.advectDye[velocity.readFace][dye.readFace],
-      dyeDispatch,
-    );
-    dye.swap();
-
-    pass.end();
-
-    const display = encoder.beginRenderPass({
-      colorAttachments: [
-        {
-          view: context.getCurrentTexture().createView(),
-          loadOp: "clear",
-          storeOp: "store",
-          clearValue: { r: 0, g: 0, b: 0, a: 1 },
-        },
-      ],
-    });
-    display.setPipeline(renderPipeline);
-    display.setBindGroup(0, current.display[dye.readFace]);
-    display.draw(3);
-    display.end();
-
-    device.queue.submit([encoder.finish()]);
   };
 
   return {

--- a/src/fluid/resources.ts
+++ b/src/fluid/resources.ts
@@ -1,0 +1,212 @@
+import { DoubleBuffer } from "./doubleBuffer";
+import type { Grid, GridPair } from "./grid";
+import type { Pipelines } from "./pipelines";
+import { DYE_FORMAT, PRESSURE_FORMAT, VELOCITY_FORMAT } from "./pipelines";
+import type { ProjectionScale } from "./projection";
+import { projectionScale } from "./projection";
+import type { FluidSettings } from "./settings";
+import { packAdvectParams, PARAM_BYTES, PARAM_FLOATS } from "./uniforms";
+
+const STORAGE_USAGE =
+  GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING;
+
+/** One bind group per face the source buffer may be on, indexed by that
+ * face — the pressure solve alone would otherwise build one per sweep. */
+export type FacePair = readonly [GPUBindGroup, GPUBindGroup];
+
+/** A pass reading two double buffers: the name says which face indexes first,
+ * since both orders type-check and swapping them binds the wrong texture. */
+type ByVelocityThenDyeFace = readonly [FacePair, FacePair];
+type ByPressureThenVelocityFace = readonly [FacePair, FacePair];
+
+export interface Resources {
+  simGrid: Grid;
+  dyeGrid: Grid;
+  scale: ProjectionScale;
+  velocity: DoubleBuffer;
+  dye: DoubleBuffer;
+  pressure: DoubleBuffer;
+  divergence: GPUTexture;
+  ownedParamBuffers: readonly GPUBuffer[];
+  advectVelocityParams: GPUBuffer;
+  advectDyeParams: GPUBuffer;
+  advectVelocity: FacePair;
+  advectDye: ByVelocityThenDyeFace;
+  splatVelocity: FacePair;
+  splatDye: FacePair;
+  divergencePass: FacePair;
+  pressurePass: FacePair;
+  gradientPass: ByPressureThenVelocityFace;
+  display: FacePair;
+}
+
+export const buildResources = (
+  device: GPUDevice,
+  pipelines: Pipelines,
+  { simGrid, dyeGrid }: GridPair,
+  settings: FluidSettings,
+): Resources => {
+  const scale = projectionScale(simGrid.width, simGrid.height);
+
+  const velocity = new DoubleBuffer(device, simGrid, VELOCITY_FORMAT);
+  const dye = new DoubleBuffer(device, dyeGrid, DYE_FORMAT);
+  const pressure = new DoubleBuffer(device, simGrid, PRESSURE_FORMAT);
+
+  const divergence = device.createTexture({
+    size: [simGrid.width, simGrid.height],
+    format: PRESSURE_FORMAT,
+    usage: STORAGE_USAGE,
+  });
+  const divergenceView = divergence.createView();
+
+  const makeParamBuffer = (values: Float32Array): GPUBuffer => {
+    const buffer = device.createBuffer({
+      size: PARAM_BYTES,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    device.queue.writeBuffer(buffer, 0, values);
+    return buffer;
+  };
+
+  const makeSplatParams = (grid: Grid, writesVelocity: number): GPUBuffer => {
+    const values = new Float32Array(PARAM_FLOATS);
+    values.set([grid.width, grid.height, writesVelocity]);
+    return makeParamBuffer(values);
+  };
+
+  const advectVelocityParams = makeParamBuffer(
+    packAdvectParams(simGrid, settings.velocityDissipation),
+  );
+  const advectDyeParams = makeParamBuffer(
+    packAdvectParams(dyeGrid, settings.dyeDissipation),
+  );
+  const splatVelocityParams = makeSplatParams(simGrid, 1);
+  const splatDyeParams = makeSplatParams(dyeGrid, 0);
+
+  const bindGroup = (
+    layout: GPUBindGroupLayout,
+    entries: GPUBindGroupEntry[],
+  ): GPUBindGroup => device.createBindGroup({ layout, entries });
+
+  const perFace = (
+    source: DoubleBuffer,
+    build: (read: GPUTextureView, write: GPUTextureView) => GPUBindGroup,
+  ): FacePair => [
+    build(source.views[0], source.views[1]),
+    build(source.views[1], source.views[0]),
+  ];
+
+  const advectVelocity = perFace(velocity, (read, write) =>
+    bindGroup(pipelines.advectLayout, [
+      { binding: 0, resource: read },
+      { binding: 1, resource: read },
+      { binding: 2, resource: write },
+      { binding: 3, resource: { buffer: advectVelocityParams } },
+    ]),
+  );
+
+  const advectDye: ByVelocityThenDyeFace = [
+    perFace(dye, (read, write) =>
+      bindGroup(pipelines.advectLayout, [
+        { binding: 0, resource: read },
+        { binding: 1, resource: velocity.views[0] },
+        { binding: 2, resource: write },
+        { binding: 3, resource: { buffer: advectDyeParams } },
+      ]),
+    ),
+    perFace(dye, (read, write) =>
+      bindGroup(pipelines.advectLayout, [
+        { binding: 0, resource: read },
+        { binding: 1, resource: velocity.views[1] },
+        { binding: 2, resource: write },
+        { binding: 3, resource: { buffer: advectDyeParams } },
+      ]),
+    ),
+  ];
+
+  const splatVelocity = perFace(velocity, (read, write) =>
+    bindGroup(pipelines.splatLayout, [
+      { binding: 0, resource: read },
+      { binding: 1, resource: write },
+      { binding: 2, resource: { buffer: splatVelocityParams } },
+    ]),
+  );
+
+  const splatDye = perFace(dye, (read, write) =>
+    bindGroup(pipelines.splatLayout, [
+      { binding: 0, resource: read },
+      { binding: 1, resource: write },
+      { binding: 2, resource: { buffer: splatDyeParams } },
+    ]),
+  );
+
+  const divergencePass = perFace(velocity, (read) =>
+    bindGroup(pipelines.divergenceLayout, [
+      { binding: 0, resource: read },
+      { binding: 1, resource: divergenceView },
+    ]),
+  );
+
+  const pressurePass = perFace(pressure, (read, write) =>
+    bindGroup(pipelines.pressureLayout, [
+      { binding: 0, resource: read },
+      { binding: 1, resource: divergenceView },
+      { binding: 2, resource: write },
+    ]),
+  );
+
+  const gradientPass: ByPressureThenVelocityFace = [
+    perFace(velocity, (read, write) =>
+      bindGroup(pipelines.gradientLayout, [
+        { binding: 0, resource: pressure.views[0] },
+        { binding: 1, resource: read },
+        { binding: 2, resource: write },
+      ]),
+    ),
+    perFace(velocity, (read, write) =>
+      bindGroup(pipelines.gradientLayout, [
+        { binding: 0, resource: pressure.views[1] },
+        { binding: 1, resource: read },
+        { binding: 2, resource: write },
+      ]),
+    ),
+  ];
+
+  const display = perFace(dye, (read) =>
+    bindGroup(pipelines.renderLayout, [{ binding: 0, resource: read }]),
+  );
+
+  return {
+    simGrid,
+    dyeGrid,
+    scale,
+    velocity,
+    dye,
+    pressure,
+    divergence,
+    ownedParamBuffers: [
+      advectVelocityParams,
+      advectDyeParams,
+      splatVelocityParams,
+      splatDyeParams,
+    ],
+    advectVelocityParams,
+    advectDyeParams,
+    advectVelocity,
+    advectDye,
+    splatVelocity,
+    splatDye,
+    divergencePass,
+    pressurePass,
+    gradientPass,
+    display,
+  };
+};
+
+export const releaseResources = (current: Resources): void => {
+  current.velocity.destroy();
+  current.dye.destroy();
+  current.pressure.destroy();
+  current.divergence.destroy();
+  for (const buffer of current.ownedParamBuffers) buffer.destroy();
+};

--- a/src/fluid/uniforms.test.ts
+++ b/src/fluid/uniforms.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+
+import { projectionScale } from "./projection";
+import type { Splat } from "./types";
+import {
+  ADVECT_PARAM,
+  packAdvectParams,
+  packSplatUniforms,
+  packUniforms,
+  PARAM_FLOATS,
+  SPLAT_UNIFORM,
+  SPLAT_UNIFORM_FLOATS,
+  UNIFORM,
+  UNIFORM_FLOATS,
+} from "./uniforms";
+
+/**
+ * The WGSL struct layouts, transcribed by hand from `simulation.wgsl`, and the
+ * packers checked against them. Inserting a member shifts every later offset
+ * and the fluid still renders — just with a wrong metric, radius or dissipation
+ * — so nothing in the picture names the member that moved.
+ *
+ * Transcribed, so this checks the host's offsets against a stated layout rather
+ * than against the shader: editing a struct means editing its twin here.
+ */
+
+/** Float width of each WGSL type, which is also its alignment: a `vec2f` aligns
+ * to 8 bytes and a `vec4f` to 16, which is what leaves the holes being pinned. */
+const f32 = 1;
+const vec2f = 2;
+const vec4f = 4;
+
+/** Padding members are omitted: they shift later offsets only by occupying
+ * space the alignment of the next member would have skipped anyway. */
+const wgslOffsets = (
+  members: readonly (readonly [string, number])[],
+): Record<string, number> => {
+  const offsets: Record<string, number> = {};
+  let cursor = 0;
+  for (const [name, floats] of members) {
+    cursor = Math.ceil(cursor / floats) * floats;
+    offsets[name] = cursor;
+    cursor += floats;
+  }
+  return offsets;
+};
+
+const UNIFORMS_STRUCT = wgslOffsets([
+  ["simSize", vec2f],
+  ["dt", f32],
+  ["aspect", f32],
+  ["toCells", vec2f],
+  ["toStored", vec2f],
+]);
+
+const SPLAT_UNIFORMS_STRUCT = wgslOffsets([
+  ["point", vec2f],
+  ["delta", vec2f],
+  ["color", vec4f],
+  ["radius", f32],
+]);
+
+const ADVECT_PARAMS_STRUCT = wgslOffsets([
+  ["gridSize", vec2f],
+  ["dissipation", f32],
+]);
+
+describe("UNIFORM", () => {
+  it("places every member where the shader reads it", () => {
+    expect(UNIFORM).toStrictEqual(UNIFORMS_STRUCT);
+  });
+
+  it("is sized to hold the struct", () => {
+    expect(UNIFORM_FLOATS).toBeGreaterThanOrEqual(UNIFORM.toStored + vec2f);
+  });
+});
+
+describe("packUniforms", () => {
+  const pack = (): Float32Array => {
+    const target = new Float32Array(UNIFORM_FLOATS);
+    packUniforms(
+      target,
+      { width: 64, height: 32 },
+      { width: 200, height: 100 },
+      projectionScale(64, 32),
+      1 / 60,
+    );
+    return target;
+  };
+
+  it("writes the simulation grid, not the dye grid, into simSize", () => {
+    const packed = pack();
+    expect([
+      packed[UNIFORM.simSize],
+      packed[UNIFORM.simSize + 1],
+    ]).toStrictEqual([64, 32]);
+  });
+
+  it("writes the timestep and the dye grid's aspect", () => {
+    const packed = pack();
+    expect(packed[UNIFORM.dt]).toBeCloseTo(1 / 60, 6);
+    expect(packed[UNIFORM.aspect]).toBeCloseTo(2);
+  });
+
+  /** The two conversions are reciprocal per axis, so swapping them reverses the
+   * metric on the GPU and the solve still converges — onto the wrong field. */
+  it("writes toCells and toStored in that order, not swapped", () => {
+    const packed = pack();
+    expect([
+      packed[UNIFORM.toCells],
+      packed[UNIFORM.toCells + 1],
+    ]).toStrictEqual([64, 32]);
+    expect(packed[UNIFORM.toStored]).toBeCloseTo(1 / 64, 6);
+    expect(packed[UNIFORM.toStored + 1]).toBeCloseTo(1 / 32, 6);
+  });
+
+  it("leaves no member unwritten", () => {
+    const target = new Float32Array(UNIFORM_FLOATS).fill(Number.NaN);
+    packUniforms(
+      target,
+      { width: 8, height: 8 },
+      { width: 8, height: 8 },
+      projectionScale(8, 8),
+      1,
+    );
+    for (const offset of Object.values(UNIFORM)) {
+      expect(target[offset]).not.toBeNaN();
+    }
+  });
+});
+
+describe("SPLAT_UNIFORM", () => {
+  it("places every member where the shader reads it", () => {
+    expect(SPLAT_UNIFORM).toStrictEqual(SPLAT_UNIFORMS_STRUCT);
+  });
+
+  /** Two `vec2f` fill floats 0-3, so `color` lands on the `vec4f` boundary with
+   * no hole — but `radius` then sits at 8, not the 7 a packed array would use. */
+  it("leaves the hole the vec4f alignment opens after color", () => {
+    expect(SPLAT_UNIFORM.color % vec4f).toBe(0);
+    expect(SPLAT_UNIFORM.radius).toBe(SPLAT_UNIFORM.color + vec4f);
+  });
+
+  it("is padded to the struct's 16-byte alignment", () => {
+    expect(SPLAT_UNIFORM_FLOATS % vec4f).toBe(0);
+    expect(SPLAT_UNIFORM_FLOATS).toBeGreaterThan(SPLAT_UNIFORM.radius);
+  });
+});
+
+describe("packSplatUniforms", () => {
+  const splat: Splat = {
+    x: 0.25,
+    y: 0.75,
+    dx: -0.5,
+    dy: 0.125,
+    color: [0.5, 0.25, 0.125],
+  };
+
+  const pack = (): Float32Array => {
+    const target = new Float32Array(SPLAT_UNIFORM_FLOATS);
+    packSplatUniforms(target, splat, 0.0035);
+    return target;
+  };
+
+  it("writes the position and the displacement into their own slots", () => {
+    const packed = pack();
+    expect([
+      ...packed.slice(SPLAT_UNIFORM.point, SPLAT_UNIFORM.point + vec2f),
+    ]).toStrictEqual([0.25, 0.75]);
+    expect([
+      ...packed.slice(SPLAT_UNIFORM.delta, SPLAT_UNIFORM.delta + vec2f),
+    ]).toStrictEqual([-0.5, 0.125]);
+  });
+
+  it("writes the three colour components at the vec4f offset", () => {
+    const packed = pack();
+    expect([
+      ...packed.slice(SPLAT_UNIFORM.color, SPLAT_UNIFORM.color + 3),
+    ]).toStrictEqual([0.5, 0.25, 0.125]);
+  });
+
+  it("writes the radius past the colour's padding", () => {
+    const packed = pack();
+    expect(packed[SPLAT_UNIFORM.radius]).toBeCloseTo(0.0035, 6);
+  });
+
+  /** The renderer reuses one array across a frame's splats, so a member the
+   * packer skipped would carry the previous splat's value into this one. */
+  it("overwrites every member rather than leaving a stale one", () => {
+    const stale = 9;
+    const target = new Float32Array(SPLAT_UNIFORM_FLOATS).fill(stale);
+    packSplatUniforms(target, splat, 0.0035);
+    for (const offset of Object.values(SPLAT_UNIFORM)) {
+      expect(target[offset]).not.toBe(stale);
+    }
+  });
+});
+
+describe("ADVECT_PARAM", () => {
+  it("places every member where the shader reads it", () => {
+    expect(ADVECT_PARAM).toStrictEqual(ADVECT_PARAMS_STRUCT);
+  });
+
+  it("fits the one vec4f the buffer is allocated at", () => {
+    expect(ADVECT_PARAM.dissipation).toBeLessThan(PARAM_FLOATS);
+  });
+});
+
+describe("packAdvectParams", () => {
+  it("writes the grid and the dissipation into their own slots", () => {
+    const packed = packAdvectParams({ width: 320, height: 180 }, 0.6);
+    expect([
+      packed[ADVECT_PARAM.gridSize],
+      packed[ADVECT_PARAM.gridSize + 1],
+    ]).toStrictEqual([320, 180]);
+    expect(packed[ADVECT_PARAM.dissipation]).toBeCloseTo(0.6);
+  });
+
+  /** `applySettings` rewrites dissipation in place at this byte offset, so a
+   * shorter buffer would put that write past the end of the allocation. */
+  it("returns a buffer the in-place dissipation write stays inside", () => {
+    const packed = packAdvectParams({ width: 8, height: 8 }, 0.2);
+    expect(packed).toHaveLength(PARAM_FLOATS);
+    expect(ADVECT_PARAM.dissipation * 4).toBeLessThan(packed.byteLength);
+  });
+});

--- a/src/fluid/uniforms.test.ts
+++ b/src/fluid/uniforms.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { projectionScale } from "./projection";
+import simulationShaderSource from "./simulation.wgsl?raw";
 import type { Splat } from "./types";
 import {
   ADVECT_PARAM,
@@ -15,55 +16,72 @@ import {
 } from "./uniforms";
 
 /**
- * The WGSL struct layouts, transcribed by hand from `simulation.wgsl`, and the
- * packers checked against them. Inserting a member shifts every later offset
- * and the fluid still renders — just with a wrong metric, radius or dissipation
- * — so nothing in the picture names the member that moved.
+ * The host's float offsets, checked against the struct layouts read out of
+ * `simulation.wgsl` itself. Inserting a member shifts every later offset and
+ * the fluid still renders — just with a wrong metric, radius or dissipation —
+ * so nothing in the picture names the member that moved.
  *
- * Transcribed, so this checks the host's offsets against a stated layout rather
- * than against the shader: editing a struct means editing its twin here.
+ * The shader is the oracle rather than a copy of it, so editing a struct fails
+ * these tests without anyone having to remember a twin lives here.
  */
 
-/** Float width of each WGSL type, which is also its alignment: a `vec2f` aligns
- * to 8 bytes and a `vec4f` to 16, which is what leaves the holes being pinned. */
-const f32 = 1;
-const vec2f = 2;
-const vec4f = 4;
+/** Float width of each type, which is also its alignment: a `vec2f` aligns to 8
+ * bytes and a `vec4f` to 16, which is what opens the holes being pinned. */
+const FLOATS: Record<string, number> = { f32: 1, vec2f: 2, vec4f: 4 };
 
-/** Padding members are omitted: they shift later offsets only by occupying
- * space the alignment of the next member would have skipped anyway. */
-const wgslOffsets = (
-  members: readonly (readonly [string, number])[],
-): Record<string, number> => {
+/** Padding members are dropped rather than assigned an offset: they occupy only
+ * space the next member's alignment would have skipped anyway. */
+const isPadding = (name: string): boolean => name.startsWith("_pad");
+
+/** Fails loudly on an unknown type or a missing struct: silently returning a
+ * partial layout would let the assertions below pass while checking less. */
+const wgslStruct = (name: string): Record<string, number> => {
+  const body = new RegExp(`\\bstruct\\s+${name}\\s*\\{([^}]*)\\}`).exec(
+    simulationShaderSource,
+  )?.[1];
+  if (body === undefined) throw new Error(`no struct ${name} in the shader`);
+
   const offsets: Record<string, number> = {};
   let cursor = 0;
-  for (const [name, floats] of members) {
+  for (const line of body.split("\n")) {
+    const member = /^\s*(\w+)\s*:\s*(\w+)\s*,/.exec(
+      line.replace(/\/\/.*$/, ""),
+    );
+    if (member === null) continue;
+    const [, memberName, type] = member;
+    const floats = FLOATS[type ?? ""];
+    if (floats === undefined) throw new Error(`unhandled type ${type ?? ""}`);
     cursor = Math.ceil(cursor / floats) * floats;
-    offsets[name] = cursor;
+    if (memberName !== undefined && !isPadding(memberName)) {
+      offsets[memberName] = cursor;
+    }
     cursor += floats;
   }
   return offsets;
 };
 
-const UNIFORMS_STRUCT = wgslOffsets([
-  ["simSize", vec2f],
-  ["dt", f32],
-  ["aspect", f32],
-  ["toCells", vec2f],
-  ["toStored", vec2f],
-]);
+const UNIFORMS_STRUCT = wgslStruct("Uniforms");
+const SPLAT_UNIFORMS_STRUCT = wgslStruct("SplatUniforms");
+const ADVECT_PARAMS_STRUCT = wgslStruct("AdvectParams");
 
-const SPLAT_UNIFORMS_STRUCT = wgslOffsets([
-  ["point", vec2f],
-  ["delta", vec2f],
-  ["color", vec4f],
-  ["radius", f32],
-]);
+const vec2f = FLOATS["vec2f"] ?? 0;
+const vec4f = FLOATS["vec4f"] ?? 0;
 
-const ADVECT_PARAMS_STRUCT = wgslOffsets([
-  ["gridSize", vec2f],
-  ["dissipation", f32],
-]);
+/** Guards the parser itself: a regex that silently matched nothing would leave
+ * every layout empty, and `toStrictEqual({})` against an empty map would pass. */
+describe("the shader-derived layouts", () => {
+  it("finds every struct the host packs into", () => {
+    expect(Object.keys(UNIFORMS_STRUCT)).not.toHaveLength(0);
+    expect(Object.keys(SPLAT_UNIFORMS_STRUCT)).not.toHaveLength(0);
+    expect(Object.keys(ADVECT_PARAMS_STRUCT)).not.toHaveLength(0);
+  });
+
+  it("drops the padding members rather than offsetting them", () => {
+    for (const name of Object.keys(SPLAT_UNIFORMS_STRUCT)) {
+      expect(isPadding(name)).toBe(false);
+    }
+  });
+});
 
 describe("UNIFORM", () => {
   it("places every member where the shader reads it", () => {

--- a/src/fluid/uniforms.ts
+++ b/src/fluid/uniforms.ts
@@ -1,16 +1,3 @@
-/**
- * The float offsets the host writes at, and the packers that fill them.
- *
- * Each map mirrors a struct in `simulation.wgsl`, and WGSL's alignment rules
- * leave holes a positional array would misfill — `SplatUniforms` pads its
- * `vec2f` pair up to the `vec4f`'s 16-byte alignment. A shifted offset still
- * renders: the fluid just gets a wrong metric, radius, or dissipation, so
- * nothing in the picture names the field that moved.
- *
- * Out here rather than inside the renderer's closure so `uniforms.test.ts` can
- * reach them, for the same reason `projection.ts` documents in its own header.
- */
-
 import type { Grid } from "./grid";
 import type { ProjectionScale } from "./projection";
 import { projectionUniform } from "./projection";

--- a/src/fluid/uniforms.ts
+++ b/src/fluid/uniforms.ts
@@ -1,0 +1,90 @@
+/**
+ * The float offsets the host writes at, and the packers that fill them.
+ *
+ * Each map mirrors a struct in `simulation.wgsl`, and WGSL's alignment rules
+ * leave holes a positional array would misfill — `SplatUniforms` pads its
+ * `vec2f` pair up to the `vec4f`'s 16-byte alignment. A shifted offset still
+ * renders: the fluid just gets a wrong metric, radius, or dissipation, so
+ * nothing in the picture names the field that moved.
+ *
+ * Out here rather than inside the renderer's closure so `uniforms.test.ts` can
+ * reach them, for the same reason `projection.ts` documents in its own header.
+ */
+
+import type { Grid } from "./grid";
+import type { ProjectionScale } from "./projection";
+import { projectionUniform } from "./projection";
+import type { Splat } from "./types";
+
+/** Float index of each `Uniforms` member in `simulation.wgsl`. */
+export const UNIFORM = {
+  simSize: 0,
+  dt: 2,
+  aspect: 3,
+  toCells: 4,
+  toStored: 6,
+} as const;
+
+export const UNIFORM_FLOATS = 8;
+export const UNIFORM_BYTES = UNIFORM_FLOATS * 4;
+
+/** Float index of each `SplatUniforms` member in `simulation.wgsl` — WGSL
+ * aligns the `vec4f` to 16 bytes, leaving a hole a positional array would
+ * misfill. */
+export const SPLAT_UNIFORM = {
+  point: 0,
+  delta: 2,
+  color: 4,
+  radius: 8,
+} as const;
+
+export const SPLAT_UNIFORM_FLOATS = 12;
+export const SPLAT_UNIFORM_BYTES = SPLAT_UNIFORM_FLOATS * 4;
+
+/** Float index of each `AdvectParams` member in `simulation.wgsl`. */
+export const ADVECT_PARAM = {
+  gridSize: 0,
+  dissipation: 2,
+} as const;
+
+/** One `vec4f` — the size every pass-parameter buffer is allocated at. */
+export const PARAM_FLOATS = 4;
+export const PARAM_BYTES = PARAM_FLOATS * 4;
+
+/** The per-frame simulation uniforms, written into `target` so the renderer can
+ * keep one array for the lifetime of the device. */
+export const packUniforms = (
+  target: Float32Array,
+  simGrid: Grid,
+  dyeGrid: Grid,
+  scale: ProjectionScale,
+  dt: number,
+): void => {
+  target.set([simGrid.width, simGrid.height], UNIFORM.simSize);
+  target[UNIFORM.dt] = dt;
+  target[UNIFORM.aspect] = dyeGrid.width / dyeGrid.height;
+  const metric = projectionUniform(scale);
+  target.set(metric.toCells, UNIFORM.toCells);
+  target.set(metric.toStored, UNIFORM.toStored);
+};
+
+export const packSplatUniforms = (
+  target: Float32Array,
+  splat: Splat,
+  radius: number,
+): void => {
+  target.set([splat.x, splat.y], SPLAT_UNIFORM.point);
+  target.set([splat.dx, splat.dy], SPLAT_UNIFORM.delta);
+  target.set(splat.color, SPLAT_UNIFORM.color);
+  target[SPLAT_UNIFORM.radius] = radius;
+};
+
+export const packAdvectParams = (
+  grid: Grid,
+  dissipation: number,
+): Float32Array => {
+  const values = new Float32Array(PARAM_FLOATS);
+  values.set([grid.width, grid.height], ADVECT_PARAM.gridSize);
+  values[ADVECT_PARAM.dissipation] = dissipation;
+  return values;
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,9 +23,12 @@ export default defineConfig({
         "src/App.tsx",
         "src/FluidCanvas.tsx",
         "src/fluid/doubleBuffer.ts",
+        "src/fluid/frame.ts",
         "src/fluid/gpu.ts",
+        "src/fluid/pipelines.ts",
         "src/fluid/resample.ts",
         "src/fluid/renderer.ts",
+        "src/fluid/resources.ts",
         "src/fluid/types.ts",
       ],
       thresholds: {


### PR DESCRIPTION
`src/fluid/renderer.ts` held pipeline construction, resource lifecycle, uniform packing and frame encoding in one 649-line closure. Its pure parts were unreachable from outside it, which is why the module had no test while every other `src/fluid` module with a pure core has one.

## What changed

Split along the seams #707 named:

| Module | Lines | Holds |
|---|---|---|
| `pipelines.ts` | 164 | shader modules, bind group layouts, pipelines — built once from the device |
| `resources.ts` | 212 | textures, param buffers, per-face bind groups, release |
| `uniforms.ts` | 90 | the float-offset maps and the packers over them, pure |
| `frame.ts` | 117 | the per-frame compute and render pass encoding |
| `renderer.ts` | 208 | composition and the mutable simulation state |

Two small changes beyond the move: `buildResources` takes `settings` as a parameter rather than closing over the mutable binding, and the two nested `FacePair` tuples get named types so the face-index order is stated rather than left to a comment.

## Why the test comes with it

The extraction's point was making the packers reachable. `uniforms.test.ts` parses the three struct bodies out of `simulation.wgsl` — the shader source the test can already reach, since vitest runs through vite — and checks the host's offsets against them.

Deriving rather than transcribing is the whole value. A hand-written twin only fails if whoever edits the shader remembers the twin exists, which is the same forgetting #708 describes; reading the shader itself removes that step. The parser throws on a missing struct or an unhandled type rather than returning a partial layout, since an empty map would pass `toStrictEqual` against nothing, and two tests guard the parser for the same reason.

Closes #707. Closes #708.

## Test plan

CI covers type-check, lint and unit tests. Beyond that:

- [x] Mutated app code in five places and confirmed the suite catches each: every offset map, a dropped `radius` write, a swapped metric pair, and sim/dye grid confusion.
- [x] Mutated **only** the shader — inserted a `vec2f` into `Uniforms` and an `f32` into `SplatUniforms`, and renamed a struct — and confirmed each fails. This is the case a transcription-based test would have passed.
- [x] Compared the new modules line by line against `git show HEAD~1:src/fluid/renderer.ts` for behaviour preservation: param-buffer zero-fill, splat slot arithmetic, construction order, and the first build's `settings` value are all unchanged.
- [x] Playwright suite: 12 pass. One failure, `stops painting when the browser revokes the pointer capture`, reproduces identically with these changes stashed — filed separately as #725.
