### PR TITLE
Drain the pointer only into a stepping frame, and floor a backwards one

### DIFF
--- a/src/FluidCanvas.tsx
+++ b/src/FluidCanvas.tsx
@@ -246,12 +246,10 @@ export const FluidCanvas = () => {
         );
         owed -= steps * TIME_STEP;
 
-        pending.push(...pointer.consume());
-
         for (let step = 0; step < steps; step++) {
-          // Drained into the first step that runs: replaying the frame's splats
-          // on each catch-up step would multiply their force by however far
-          // behind the loop had fallen.
+          // First step only, because accruing across stepless frames overflows
+          // the cap renderer.ts silently slices at, and replaying scales force.
+          if (step === 0) pending.push(...pointer.consume());
           renderer?.frame(pending);
           pending = [];
         }

--- a/src/fluid/motion.test.ts
+++ b/src/fluid/motion.test.ts
@@ -39,6 +39,12 @@ describe("creditedElapsed", () => {
     expect(creditedElapsed(2)).toBeCloseTo(budget, 6);
   });
 
+  it("floors a backwards frame, so no step is banked from nothing", () => {
+    // Because Chromium was measured giving the first rAF callback a timestamp
+    // 4.3ms before its own performance.now(); unfloored that banks a step.
+    expect(creditedElapsed(-4.3 / 1000)).toBe(0);
+  });
+
   it("still advances a slow frame rather than freezing the simulation", () => {
     // A software renderer on CI exceeds the budget every frame; returning 0 here
     // would stop the solver entirely and the dye would never decay.

--- a/src/fluid/motion.ts
+++ b/src/fluid/motion.ts
@@ -19,10 +19,10 @@ export const reducedMotionQuery = (view: MotionQueryView): MotionQuery | null =>
  * frame, and discarding those gaps would stop the simulation advancing at all. */
 const MAX_FRAME_GAP_SECONDS = MAX_STEPS_PER_FRAME * TIME_STEP;
 
-/** Separate from the closed-gate branch because `visibilitychange` reopens the
- * gate before the first resumed frame, so that gap sees an open one. */
+/** Capped for the gap `visibilitychange` lets through with the gate open;
+ * floored because rAF can timestamp before the `performance.now()` before it. */
 export const creditedElapsed = (elapsed: number): number =>
-  Math.min(elapsed, MAX_FRAME_GAP_SECONDS);
+  Math.min(Math.max(elapsed, 0), MAX_FRAME_GAP_SECONDS);
 
 export class MotionGate {
   private reducedMotion: boolean;


### PR DESCRIPTION
Two fixes in the frame loop. The first is #706; the second was found while reviewing the first.

## Draining only into a step (#706)

The loop drained `PointerTracker` every animation frame, but only hands `pending` to the renderer when a simulation step runs. On a display faster than `TIME_STEP` some frames run no step, so splats accrued one per pointer per stepless frame, and `renderer.ts` slices at `MAX_SPLATS_PER_FRAME` and drops the rest in silence.

Draining on the first step instead lets the tracker coalesce the motion it already accumulates per `pointerId`, so the same travel arrives as one splat rather than several. Simultaneous pointers needed to reach the cap:

| display | before | after |
|---|---|---|
| 120Hz | 7 | 13 |
| 240Hz | 4 | 13 |
| 360Hz | 3 | 13 |

Once the seed burst has drained it takes 33. The `renderer.frame()` call pattern is unchanged for every step count — only the number of `consume()` calls falls.

## Flooring a backwards frame

`requestAnimationFrame` can hand its callback a timestamp earlier than the `performance.now()` taken to seed `previous`. `creditedElapsed` clamped only the top, so that reached the loop as `Math.floor(-0.0043 / TIME_STEP)` = −1 step, and `owed -= steps * TIME_STEP` credited 16.7ms of simulation nobody earned.

Measured in Chromium rather than reasoned from the spec: `previous` 9867.6, rAF timestamp 9863.3, elapsed −4.3ms, on 1 of 12 rounds. Swept from −0.05 to 1.0, only negative inputs behave differently; the budget edge, long gaps and `Infinity` are untouched, and `creditedElapsed` has one production caller.

## What is not covered

The `#706` fix is **not pinned by any test**. `FluidCanvas.tsx` is excluded from coverage and the loop needs a GPU adapter happy-dom has no implementation of, so reverting that one-line guard leaves the suite green — confirmed by mutation. The floor fix is pinned, and its test fails when the floor is reverted.

CI's E2E job passes, but it runs headless at 60Hz, where every open frame steps — so it exercises the changed line without reaching the stepless path the fix is about.

## Deliberately left

A tap that never moves is dropped, and this change widens the window in which that can happen from one display frame to one simulation step. Fixing it collides with an existing test that encodes the opposite contract, so it is a spec question rather than a bug fix — filed as #728 and left at the current behaviour.

## Test plan

- [x] `pnpm run test` — 152 pass
- [x] `pnpm run lint` — eslint, prettier, three tsc projects clean
- [x] CI — E2ETests, Deploy, Build, Lint, Test all green
- [ ] Exercise a real drag on a >60Hz display, which is the only way to observe the coalescing the first fix relies on

Closes #706