### PR TITLE
Pin the frame schedule by extracting it from the effect

### DIFF
--- a/src/FluidCanvas.tsx
+++ b/src/FluidCanvas.tsx
@@ -1,16 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { MAX_STEPS_PER_FRAME, TIME_STEP } from "@/fluid/config";
 import { GpuUnavailableError, initGpu } from "@/fluid/gpu";
-import {
-  creditedElapsed,
-  MotionGate,
-  reducedMotionQuery,
-} from "@/fluid/motion";
+import { MotionGate, reducedMotionQuery } from "@/fluid/motion";
 import { PointerTracker } from "@/fluid/pointer";
 import { createFluidRenderer } from "@/fluid/renderer";
 import type { ResolutionSettings } from "@/fluid/resolution";
 import { DEFAULT_RESOLUTION, sameResolution } from "@/fluid/resolution";
+import { FrameSchedule } from "@/fluid/schedule";
 import { seedEnabled, seedSplats } from "@/fluid/seed";
 import type { FluidSettings } from "@/fluid/settings";
 import { DEFAULT_SETTINGS } from "@/fluid/settings";
@@ -20,7 +16,7 @@ import {
   saveResolution,
   saveSettings,
 } from "@/fluid/settingsStorage";
-import type { FluidRenderer, Splat } from "@/fluid/types";
+import type { FluidRenderer } from "@/fluid/types";
 import { GpuNotice } from "@/GpuNotice";
 import { SettingsPanel } from "@/SettingsPanel";
 
@@ -220,39 +216,26 @@ export const FluidCanvas = () => {
       observer.observe(canvas);
 
       let previous = performance.now();
-      let owed = 0;
-      // Held until the first step runs: the loop may render before enough time
-      // has accumulated for a step, and the burst has to land inside one.
-      let pending: Splat[] =
+      const schedule = new FrameSchedule(
         motion.seeds && seedEnabled(window.location.search)
           ? seedSplats(Math.random)
-          : [];
+          : [],
+      );
 
       const loop = (now: number): void => {
         const elapsed = (now - previous) / 1000;
         previous = now;
 
         if (!motion.open) {
-          owed = 0;
+          schedule.pause();
           frameId = requestAnimationFrame(loop);
           return;
         }
 
-        owed += creditedElapsed(elapsed);
-
-        const steps = Math.min(
-          Math.floor(owed / TIME_STEP),
-          MAX_STEPS_PER_FRAME,
-        );
-        owed -= steps * TIME_STEP;
-
-        for (let step = 0; step < steps; step++) {
-          // First step only, because accruing across stepless frames overflows
-          // the cap renderer.ts silently slices at, and replaying scales force.
-          if (step === 0) pending.push(...pointer.consume());
-          renderer?.frame(pending);
-          pending = [];
-        }
+        schedule.advance(elapsed, {
+          consume: () => pointer.consume(),
+          frame: (splats) => renderer?.frame(splats),
+        });
 
         frameId = requestAnimationFrame(loop);
       };

--- a/src/fluid/schedule.test.ts
+++ b/src/fluid/schedule.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { MAX_STEPS_PER_FRAME, TIME_STEP } from "./config";
+import { FrameSchedule } from "./schedule";
+import type { Splat } from "./types";
+
+const splat = (x: number): Splat => ({
+  x,
+  y: 0.5,
+  dx: 0,
+  dy: 0,
+  color: [1, 1, 1],
+});
+
+const sink = (produce: () => readonly Splat[] = () => [splat(0.5)]) => {
+  const frames: (readonly Splat[])[] = [];
+  return {
+    frames,
+    consume: vi.fn(produce),
+    frame: vi.fn((splats: readonly Splat[]) => frames.push([...splats])),
+  };
+};
+
+describe("FrameSchedule", () => {
+  it("runs no step, and drains nothing, until a step's worth of time accrues", () => {
+    const schedule = new FrameSchedule();
+    const s = sink();
+
+    expect(schedule.advance(TIME_STEP / 2, s)).toBe(0);
+    expect(s.consume).not.toHaveBeenCalled();
+    expect(s.frame).not.toHaveBeenCalled();
+  });
+
+  it("drains once when two half-steps add up, not once per frame", () => {
+    const schedule = new FrameSchedule();
+    const s = sink();
+
+    schedule.advance(TIME_STEP / 2, s);
+    expect(schedule.advance(TIME_STEP / 2, s)).toBe(1);
+
+    expect(s.consume).toHaveBeenCalledTimes(1);
+    expect(s.frames).toEqual([[splat(0.5)]]);
+  });
+
+  it("holds the drain across a long stepless run rather than accruing per frame", () => {
+    const schedule = new FrameSchedule();
+    const s = sink();
+
+    // Because 360Hz was measured running five stepless frames between steps,
+    // each of which used to add a splat per pointer toward the silent cap.
+    for (let frame = 0; frame < 5; frame++) schedule.advance(1 / 360, s);
+    expect(s.consume).not.toHaveBeenCalled();
+
+    schedule.advance(1 / 360, s);
+    expect(s.consume).toHaveBeenCalledTimes(1);
+    expect(s.frames.at(0)).toHaveLength(1);
+  });
+
+  it("gives the splats to the first catch-up step and nothing to the rest", () => {
+    const schedule = new FrameSchedule();
+    const s = sink();
+
+    expect(schedule.advance(TIME_STEP * MAX_STEPS_PER_FRAME, s)).toBe(
+      MAX_STEPS_PER_FRAME,
+    );
+
+    expect(s.consume).toHaveBeenCalledTimes(1);
+    expect(s.frames).toEqual([[splat(0.5)], [], [], []]);
+  });
+
+  it("caps a stall at what one frame can drain", () => {
+    const schedule = new FrameSchedule();
+    const s = sink();
+
+    expect(schedule.advance(60, s)).toBe(MAX_STEPS_PER_FRAME);
+  });
+
+  it("lands the seed burst inside the first step rather than dropping it", () => {
+    const seeds = [splat(0.1), splat(0.2)];
+    const schedule = new FrameSchedule(seeds);
+    const s = sink();
+
+    schedule.advance(TIME_STEP / 2, s);
+    expect(s.frame).not.toHaveBeenCalled();
+
+    schedule.advance(TIME_STEP / 2, s);
+    expect(s.frames).toEqual([[...seeds, splat(0.5)]]);
+  });
+
+  it("keeps the caller's seed array out of its own state", () => {
+    const seeds = [splat(0.1)];
+    const schedule = new FrameSchedule(seeds);
+    seeds.push(splat(0.9));
+
+    const s = sink(() => []);
+    schedule.advance(TIME_STEP, s);
+    expect(s.frames).toEqual([[splat(0.1)]]);
+  });
+
+  it("drops the accrued budget on pause, so a reopened gate replays nothing", () => {
+    const schedule = new FrameSchedule();
+    const s = sink();
+
+    schedule.advance(TIME_STEP * 0.9, s);
+    schedule.pause();
+
+    expect(schedule.advance(TIME_STEP * 0.9, s)).toBe(0);
+  });
+
+  it("still steps on a backwards frame's successor, banking nothing from it", () => {
+    const schedule = new FrameSchedule();
+    const s = sink();
+
+    // Because Chromium was measured giving the first rAF callback a timestamp
+    // before the performance.now() that seeded it; unfloored this banks a step.
+    expect(schedule.advance(-4.3 / 1000, s)).toBe(0);
+    expect(schedule.advance(TIME_STEP, s)).toBe(1);
+  });
+});

--- a/src/fluid/schedule.test.ts
+++ b/src/fluid/schedule.test.ts
@@ -107,6 +107,20 @@ describe("FrameSchedule", () => {
     expect(schedule.advance(TIME_STEP * 0.9, s)).toBe(0);
   });
 
+  it("keeps the seed burst across a pause, so a background tab still opens lit", () => {
+    const seeds = [splat(0.1), splat(0.2)];
+    const schedule = new FrameSchedule(seeds);
+    const s = sink(() => []);
+
+    // A tab opened hidden is !motion.open every frame until it is shown, so
+    // the burst has to survive however many pauses precede the first step.
+    schedule.pause();
+    schedule.pause();
+
+    schedule.advance(TIME_STEP, s);
+    expect(s.frames).toEqual([seeds]);
+  });
+
   it("still steps on a backwards frame's successor, banking nothing from it", () => {
     const schedule = new FrameSchedule();
     const s = sink();

--- a/src/fluid/schedule.ts
+++ b/src/fluid/schedule.ts
@@ -1,0 +1,46 @@
+import { MAX_STEPS_PER_FRAME, TIME_STEP } from "./config";
+import { creditedElapsed } from "./motion";
+import type { Splat } from "./types";
+
+export interface FrameSink {
+  consume: () => readonly Splat[];
+  frame: (splats: readonly Splat[]) => void;
+}
+
+/** Apart from the effect because `FluidCanvas`'s renderer needs a GPU adapter,
+ * so a rule left inline there is reachable by no unit test. */
+export class FrameSchedule {
+  private owed = 0;
+  private pending: Splat[];
+
+  /** Held rather than drawn now, because a frame can render before enough time
+   * accrues for a step and the burst has to land inside one. */
+  constructor(seeds: readonly Splat[] = []) {
+    this.pending = [...seeds];
+  }
+
+  /** Discarded because a reopened gate would otherwise replay the whole gap. */
+  pause(): void {
+    this.owed = 0;
+  }
+
+  advance(elapsedSeconds: number, sink: FrameSink): number {
+    this.owed += creditedElapsed(elapsedSeconds);
+
+    const steps = Math.min(
+      Math.floor(this.owed / TIME_STEP),
+      MAX_STEPS_PER_FRAME,
+    );
+    this.owed -= steps * TIME_STEP;
+
+    for (let step = 0; step < steps; step++) {
+      // First step only, because accruing across stepless frames overflows the
+      // cap renderer.ts silently slices at, and replaying scales the force.
+      if (step === 0) this.pending.push(...sink.consume());
+      sink.frame(this.pending);
+      this.pending = [];
+    }
+
+    return steps;
+  }
+}


### PR DESCRIPTION
#729 landed a drain rule that no test could reach. `FluidCanvas.tsx` is excluded from coverage, its renderer needs a GPU adapter happy-dom has no implementation of, and reverting the one-line guard left all 152 tests green — the original #706 bug had survived for exactly that reason.

`FrameSchedule` takes the step budgeting, the seed hold and the drain rule; the loop passes `consume`/`frame` as callbacks and shrinks from ~24 lines to 5. No behaviour change is intended.

## Equivalence is measured, not asserted

The pre-extraction loop body was transcribed and run head-to-head against `FrameSchedule` over 4000 randomised frames — 60–360Hz, stalls, backwards frames, periodic pauses, with and without a seed burst. Step counts and frame payloads match exactly on every frame.

## What each layer pins, mutation-checked

| rule | pinned by | mutation |
|---|---|---|
| drain on the first step only | 4 unit tests | unconditional drain → 4 fail |
| splats reach only the first catch-up step | 1 unit test | replaying on each → fails |
| a pause keeps the seed burst | 1 unit test | clearing `pending` → fails |
| `advance` is actually called | e2e drag test | call deleted → `litFraction` stays 0, e2e fails |

The last row is the one unit tests cannot cover: deleting the whole `schedule.advance(...)` call leaves all 162 green. That was verified by building the mutant and running the e2e drag test against it, rather than assumed.

The pause row came from a review of the first commit here — the same unpinned-behaviour shape that commit set out to close, one method over.

## Still not covered

Nothing here reaches the stepless path at 60Hz, so CI exercises the changed lines without exercising the condition the rule is about. That needs a display faster than 60Hz and remains the open item from #729.

## Test plan

- [x] `pnpm run test` — 162 pass
- [x] `pnpm run test:coverage` — 100% statements / branches / functions / lines, with `schedule.ts` outside the exclusion list
- [x] `pnpm run lint` — eslint, prettier, three tsc projects clean
- [x] Differential test against the transcribed inline loop, 4000 frames
- [x] e2e drag test run against a wiring-mutant build, confirmed failing